### PR TITLE
Add shellscript to generate build files for Linux

### DIFF
--- a/xdelta3/generate_build_files.sh
+++ b/xdelta3/generate_build_files.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+aclocal &&
+    autoreconf --install &&
+    libtoolize &&
+    autoconf &&
+    automake --add-missing &&
+    automake

--- a/xdelta3/install-sh
+++ b/xdelta3/install-sh
@@ -1,1 +1,0 @@
-/opt/local/share/automake-1.15/install-sh


### PR DESCRIPTION
Trying to make life easier on people trying to build from source. For those not
familiar with the autotools suite (such as myself), this presents a barrier to entry
that's pretty frustrating, especially given the lack of documentation.

I also removed the symlink to install-sh, as it was dangling on my machine,
and it will be generated by the new shell script anyways.

I didn't try to add any documentation because I wasn't sure what exactly would
have been wanted; whether you wanted it in the README or in the wiki, and other
details. I'd be more than happy to do that given some direction.
