### PR TITLE
Fix assertion related compile failure

### DIFF
--- a/xdelta3/Makefile.am
+++ b/xdelta3/Makefile.am
@@ -73,7 +73,7 @@ WFLAGS = -Wall -Wshadow -fno-builtin -Wextra -Wsign-compare \
  # -Wno-variadic-macros \
  # -Wno-c++98-compat-pedantic
 
-C_WFLAGS = $(WFLAGS) -std=c99
+C_WFLAGS = $(WFLAGS) -std=c11
 CXX_WFLAGS = $(WFLAGS) -std=c++11
 
 common_CFLAGS = \

--- a/xdelta3/xdelta3.h
+++ b/xdelta3/xdelta3.h
@@ -30,6 +30,7 @@
 #include "config.h"
 #endif
 
+#include <assert.h>
 #include <errno.h>
 #include <stdarg.h>
 #include <stddef.h>


### PR DESCRIPTION
`static_assert` is declared in `assert.h` and should only be used after C11.