### PR TITLE
Handle block devices in main_file_stat, fixes "non-seekable" source bug for block devices

### DIFF
--- a/xdelta3/xdelta3-main.h
+++ b/xdelta3/xdelta3-main.h
@@ -106,6 +106,10 @@ xsnprintf_func (char *str, size_t n, const char *fmt, ...)
 #include <unistd.h> /* lots */
 #include <sys/time.h> /* gettimeofday() */
 #include <sys/stat.h> /* stat() and fstat() */
+#include <sys/ioctl.h> /* ioctl() */
+#ifndef BLKGETSIZE64
+#   define BLKGETSIZE64 _IOR(0x12,114,size_t)
+#endif
 #else
 #if defined(_MSC_VER)
 #define strtoll _strtoi64
@@ -944,11 +948,23 @@ main_file_stat (main_file *xfile, xoff_t *size)
       return ret;
     }
 
-  if (! S_ISREG (sbuf.st_mode))
+  if (S_ISBLK (sbuf.st_mode))
+    {
+      uint64_t blk_size;
+      if (ioctl (XFNO (xfile), BLKGETSIZE64, &blk_size) < 0)
+        {
+          return get_errno ();
+        }
+      (*size) = (xoff_t)blk_size;
+    }
+  else if (S_ISREG (sbuf.st_mode))
+    {
+      (*size) = sbuf.st_size;
+    }
+  else
     {
       return ESPIPE;
     }
-  (*size) = sbuf.st_size;
 #endif
   return ret;
 }


### PR DESCRIPTION
Fixes the function for checking if the source is seekable (`main_stat_file`), so that block devices are correctly identified as seekable.

Currently, xdelta3 throws the following error when checking if block devices are seekable:
```
non-seekable source in decode: XD3_INTERNAL
```

Changes:
* Added inclusion of `<sys/ioctl.h>` and defined the `BLKGETSIZE64` macro for block device size retrieval in `xdelta3/xdelta3-main.h`.
* Updated `main_file_stat` to detect block devices using `S_ISBLK`, retrieve their size with `ioctl` and `BLKGETSIZE64`, and set the file size accordingly.