### PR TITLE
Fix block-device sources misclassified as non-seekable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,28 @@ jobs:
       - name: Test
         run: ctest --test-dir build -C Release --output-on-failure
 
+  blockdev-test:
+    name: ${{ matrix.os }} / block-device source
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
+    defaults:
+      run:
+        working-directory: xdelta3
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Configure
+        run: cmake -B build -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build
+        run: cmake --build build --config Release -j
+
+      - name: Block-device source test
+        run: ./testing/blockdev_test.sh ./build/xdelta3
+
   go-regtest:
     name: go regression harness
     runs-on: ubuntu-latest

--- a/xdelta3/testing/blockdev_test.sh
+++ b/xdelta3/testing/blockdev_test.sh
@@ -1,0 +1,133 @@
+#!/bin/sh
+#
+# Regression test for block-device sources (see main_blockdev_size in
+# xdelta3-main.h).
+#
+# stat() reports st_size == 0 for a block device, so the historical code
+# rejected it as non-regular and the source fell into non-seekable (FIFO)
+# mode, which refuses backward source copies with:
+#
+#     non-seekable source in decode: XD3_INTERNAL
+#
+# This test attaches a real block device backed by a known image and decodes
+# a delta whose copies reach backward past the decode window.  A correctly
+# sized, seekable source handles this by seeking; a mis-classified FIFO source
+# fails.  The test also asserts the verbose output reports a known size rather
+# than "(FIFO)".
+#
+# Creating a block device is OS-specific and may need privileges:
+#   * macOS: hdiutil (no privileges required)
+#   * Linux: losetup (needs sudo)
+# On any platform where a device cannot be created the test prints SKIP and
+# exits 0 so it never produces a spurious failure.
+#
+# Usage: blockdev_test.sh [path-to-xdelta3]
+
+set -eu
+
+XD=${1:-}
+if [ -z "$XD" ]; then
+  for cand in ./build/xdelta3 ./xdelta3 build/xdelta3; do
+    if [ -x "$cand" ]; then XD=$cand; break; fi
+  done
+fi
+if [ -z "$XD" ] || [ ! -x "$XD" ]; then
+  echo "blockdev_test: cannot find xdelta3 binary (pass it as \$1)" >&2
+  exit 2
+fi
+
+WORK=$(mktemp -d "${TMPDIR:-/tmp}/xd3-blockdev.XXXXXX")
+DEV=""
+OS=$(uname -s)
+
+cleanup() {
+  if [ -n "$DEV" ]; then
+    case "$OS" in
+      Darwin) hdiutil detach "$DEV" >/dev/null 2>&1 || true ;;
+      Linux)  sudo losetup -d "$DEV" >/dev/null 2>&1 || true ;;
+    esac
+  fi
+  rm -rf "$WORK"
+}
+trap cleanup EXIT INT TERM
+
+skip() {
+  echo "blockdev_test: SKIP: $1"
+  exit 0
+}
+
+# --- Build the inputs --------------------------------------------------------
+# A 3 MiB source, and a target that is the two halves swapped.  Decoding the
+# delta therefore requires copying the first half (source offset 0) *after*
+# the second half (source offset 1.5 MiB): a 1.5 MiB backward copy.
+SRC="$WORK/src.bin"
+TGT="$WORK/tgt.bin"
+DELTA="$WORK/delta.xd"
+SIZE=3145728            # 3 MiB (not a power of two)
+HALF=$((SIZE / 2))
+
+dd if=/dev/urandom of="$SRC" bs=1024 count=$((SIZE / 1024)) 2>/dev/null
+dd if="$SRC" bs="$HALF" skip=1 of="$TGT" 2>/dev/null
+dd if="$SRC" bs="$HALF" count=1 >>"$TGT" 2>/dev/null
+
+# Encode with a large window so the backward match is found; decode below uses
+# a small window so the copy reaches back past it.
+ENC_B=4194304          # 4 MiB
+DEC_B=524288           # 512 KiB (xdelta3's minimum -B)
+
+"$XD" -e -f -B "$ENC_B" -s "$SRC" "$TGT" "$DELTA"
+
+# Control: a regular-file source seeks and round-trips even with the small
+# decode window.  If this fails the test itself is broken, so error out.
+"$XD" -d -f -B "$DEC_B" -s "$SRC" "$DELTA" "$WORK/out.regular"
+if ! cmp -s "$TGT" "$WORK/out.regular"; then
+  echo "blockdev_test: FAIL: regular-file control decode did not round-trip" >&2
+  exit 1
+fi
+
+# --- Attach the image as a block device --------------------------------------
+case "$OS" in
+  Darwin)
+    command -v hdiutil >/dev/null 2>&1 || skip "hdiutil not available"
+    DEV=$(hdiutil attach -nomount -imagekey diskimage-class=CRawDiskImage "$SRC" \
+            2>/dev/null | awk 'NR==1 {print $1}') || true
+    [ -n "$DEV" ] && [ -b "$DEV" ] || skip "could not attach block device via hdiutil"
+    ;;
+  Linux)
+    command -v losetup >/dev/null 2>&1 || skip "losetup not available"
+    command -v sudo >/dev/null 2>&1 || skip "sudo not available for losetup"
+    sudo -n true >/dev/null 2>&1 || skip "sudo requires a password; cannot attach loop device"
+    DEV=$(sudo losetup --find --show "$SRC" 2>/dev/null) || true
+    [ -n "$DEV" ] && [ -b "$DEV" ] || skip "could not attach loop device"
+    sudo chmod a+r "$DEV" 2>/dev/null || true
+    ;;
+  *)
+    skip "no block-device support for $OS"
+    ;;
+esac
+
+echo "blockdev_test: using device $DEV"
+
+# --- The actual assertion ----------------------------------------------------
+# Decode with the small window against the block device.  Verbose output must
+# report a known size (not "(FIFO)"/"unknown"), and the output must round-trip.
+LOG="$WORK/decode.log"
+if ! "$XD" -d -f -v -v -B "$DEC_B" -s "$DEV" "$DELTA" "$WORK/out.device" >"$LOG" 2>&1; then
+  echo "blockdev_test: FAIL: decode against block device errored:" >&2
+  sed 's/^/    /' "$LOG" >&2
+  exit 1
+fi
+
+if ! cmp -s "$TGT" "$WORK/out.device"; then
+  echo "blockdev_test: FAIL: block-device decode did not round-trip" >&2
+  exit 1
+fi
+
+if grep -qiE 'fifo|source size unknown' "$LOG"; then
+  echo "blockdev_test: FAIL: block device was treated as non-seekable (FIFO):" >&2
+  grep -iE 'source|fifo' "$LOG" | sed 's/^/    /' >&2
+  exit 1
+fi
+
+echo "blockdev_test: PASS ($DEV sized and seekable; backward copy decoded)"
+exit 0

--- a/xdelta3/xdelta3-main.h
+++ b/xdelta3/xdelta3-main.h
@@ -106,6 +106,14 @@ xsnprintf_func (char *str, size_t n, const char *fmt, ...)
 #include <unistd.h> /* lots */
 #include <sys/time.h> /* gettimeofday() */
 #include <sys/stat.h> /* stat() and fstat() */
+#if defined(__linux__)
+#include <sys/ioctl.h>
+#include <linux/fs.h> /* BLKGETSIZE64 */
+#elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__DragonFly__) || \
+      defined(__NetBSD__) || defined(__OpenBSD__)
+#include <sys/ioctl.h>
+#include <sys/disk.h> /* DKIOCGETBLOCK*, DIOCGMEDIASIZE */
+#endif
 #else
 #if defined(_MSC_VER)
 #define strtoll _strtoi64
@@ -908,6 +916,49 @@ main_file_open (main_file *xfile, const char* name, int mode)
   return ret;
 }
 
+#ifndef _WIN32
+/* Query the byte size of an open block device.  There is no portable
+ * POSIX way to do this, so each platform needs its own ioctl.  On
+ * success returns 0 and sets *size; on failure (including platforms
+ * with no known method) returns an errno, in which case the caller
+ * treats the source as unsized (the historical degraded behavior). */
+static int
+main_blockdev_size (int fd, xoff_t *size)
+{
+#if defined(__linux__) && defined(BLKGETSIZE64)
+  uint64_t bytes = 0;
+  if (ioctl (fd, BLKGETSIZE64, &bytes) < 0)
+    {
+      return get_errno ();
+    }
+  (*size) = (xoff_t) bytes;
+  return 0;
+#elif defined(__APPLE__) && defined(DKIOCGETBLOCKCOUNT)
+  uint32_t blocksize = 0;
+  uint64_t blockcount = 0;
+  if (ioctl (fd, DKIOCGETBLOCKSIZE, &blocksize) < 0 ||
+      ioctl (fd, DKIOCGETBLOCKCOUNT, &blockcount) < 0)
+    {
+      return get_errno ();
+    }
+  (*size) = (xoff_t) blockcount * (xoff_t) blocksize;
+  return 0;
+#elif defined(DIOCGMEDIASIZE)
+  off_t bytes = 0; /* FreeBSD/DragonFly */
+  if (ioctl (fd, DIOCGMEDIASIZE, &bytes) < 0)
+    {
+      return get_errno ();
+    }
+  (*size) = (xoff_t) bytes;
+  return 0;
+#else
+  (void) fd;
+  (void) size;
+  return ENOTTY; /* No known method; caller falls back to unsized. */
+#endif
+}
+#endif /* !_WIN32 */
+
 int
 main_file_stat (main_file *xfile, xoff_t *size)
 {
@@ -944,11 +995,24 @@ main_file_stat (main_file *xfile, xoff_t *size)
       return ret;
     }
 
-  if (! S_ISREG (sbuf.st_mode))
+  if (S_ISREG (sbuf.st_mode))
+    {
+      (*size) = sbuf.st_size;
+    }
+  else if (S_ISBLK (sbuf.st_mode))
+    {
+      /* stat() reports st_size == 0 for block devices; query the real
+       * device size so the source is treated as seekable and sized
+       * rather than falling into non-seekable (FIFO) mode. */
+      if ((ret = main_blockdev_size (XFNO (xfile), size)))
+        {
+          return ret;
+        }
+    }
+  else
     {
       return ESPIPE;
     }
-  (*size) = sbuf.st_size;
 #endif
   return ret;
 }

--- a/xdelta3/xdelta3-main.h
+++ b/xdelta3/xdelta3-main.h
@@ -916,7 +916,7 @@ main_file_open (main_file *xfile, const char* name, int mode)
   return ret;
 }
 
-#ifndef _WIN32
+#ifdef S_ISBLK
 /* Query the byte size of an open block device.  There is no portable
  * POSIX way to do this, so each platform needs its own ioctl.  On
  * success returns 0 and sets *size; on failure (including platforms
@@ -957,7 +957,7 @@ main_blockdev_size (int fd, xoff_t *size)
   return ENOTTY; /* No known method; caller falls back to unsized. */
 #endif
 }
-#endif /* !_WIN32 */
+#endif /* S_ISBLK */
 
 int
 main_file_stat (main_file *xfile, xoff_t *size)
@@ -999,6 +999,7 @@ main_file_stat (main_file *xfile, xoff_t *size)
     {
       (*size) = sbuf.st_size;
     }
+#ifdef S_ISBLK
   else if (S_ISBLK (sbuf.st_mode))
     {
       /* stat() reports st_size == 0 for block devices; query the real
@@ -1009,6 +1010,7 @@ main_file_stat (main_file *xfile, xoff_t *size)
           return ret;
         }
     }
+#endif
   else
     {
       return ESPIPE;


### PR DESCRIPTION
stat() reports st_size == 0 for a block device, so main_file_stat rejected it as non-regular (ESPIPE). The source was then treated as unsized and forced into non-seekable (FIFO) mode, which refuses backward source copies with "non-seekable source in decode: XD3_INTERNAL".

Add a portable main_blockdev_size() that queries the real device size so the source is treated as sized and seekable:

  * Linux: BLKGETSIZE64
  * macOS: DKIOCGETBLOCKSIZE x DKIOCGETBLOCKCOUNT
  * *BSD:  DIOCGMEDIASIZE
  * else:  ENOTTY, falling back to the historical unsized behavior

Add testing/blockdev_test.sh, which attaches a real block device (macOS hdiutil / Linux losetup) and decodes a delta whose copies reach backward past the decode window; it fails on the old code and passes with the fix, and skips cleanly where devices can't be created. Wire it into CI as a new blockdev-test job on ubuntu-latest and macos-latest.

Replaces #282.