### PR TITLE
Harden allocation sizing against integer overflow

### DIFF
--- a/xdelta3/xdelta3-internal.h
+++ b/xdelta3/xdelta3-internal.h
@@ -360,6 +360,15 @@ static inline int xd3_emit_offset (xd3_stream *stream, xd3_output **output, xoff
 #define USIZE_T_OVERFLOW(a,b) ((USIZE_T_MAX - (usize_t) (a)) < (usize_t) (b))
 #define XOFF_T_OVERFLOW(a,b) ((XOFF_T_MAX - (xoff_t) (a)) < (xoff_t) (b))
 
+/* Multiplication-overflow guard for allocation sizes.  The product is
+ * evaluated in size_t, the type the allocators pass to malloc.  A wrap
+ * here would yield an undersized buffer and a subsequent heap
+ * overflow.  Evaluates to non-zero when items * size would overflow
+ * size_t.  Both operands are evaluated once. */
+#define XD3_MUL_SIZE_OVERFLOW(items,size)				\
+  (((size_t) (size) != 0) &&						\
+   ((size_t) (items) > ((size_t) SIZE_MAX) / (size_t) (size)))
+
 int xd3_size_hashtable (xd3_stream   *stream,
 			usize_t       slots,
 			usize_t       look,

--- a/xdelta3/xdelta3-main.h
+++ b/xdelta3/xdelta3-main.h
@@ -470,6 +470,10 @@ main_alloc (void   *opaque,
 	    size_t  items,
 	    usize_t  size)
 {
+  if (XD3_MUL_SIZE_OVERFLOW (items, size))
+    {
+      return NULL;
+    }
   return main_malloc1 (items * size);
 }
 
@@ -3611,6 +3615,13 @@ setup_environment (int argc,
   }
 
   (*env_free) = (char*) main_malloc((usize_t) strlen(v) + 1);
+  if (*env_free == NULL) {
+    /* Allocation failed; fall back to the unmodified command line. */
+    (*argc_out) = argc;
+    (*argv_out) = argv;
+    (*argv_free) = NULL;
+    return;
+  }
   strcpy(*env_free, v);
 
   /* Space needed for extra args, at least # of spaces */
@@ -3621,7 +3632,27 @@ setup_environment (int argc,
     }
   }
 
-  (*argv_free) = (char**) main_malloc(sizeof(char*) * (n + 1));
+  /* Guard the argv allocation size against integer overflow before
+   * multiplying.  On overflow, discard the parsed environment and fall
+   * back to the unmodified command line. */
+  if (n < 0 || XD3_MUL_SIZE_OVERFLOW (sizeof(char*), (size_t) n + 1)) {
+    main_free1 (NULL, *env_free);
+    (*env_free) = NULL;
+    (*argc_out) = argc;
+    (*argv_out) = argv;
+    (*argv_free) = NULL;
+    return;
+  }
+
+  (*argv_free) = (char**) main_malloc(sizeof(char*) * ((size_t) n + 1));
+  if (*argv_free == NULL) {
+    main_free1 (NULL, *env_free);
+    (*env_free) = NULL;
+    (*argc_out) = argc;
+    (*argv_out) = argv;
+    (*argv_free) = NULL;
+    return;
+  }
   (*argv_out) = (*argv_free);
   (*argv_out)[0] = argv[0];
   (*argv_out)[n] = NULL;

--- a/xdelta3/xdelta3-test.h
+++ b/xdelta3/xdelta3-test.h
@@ -718,6 +718,68 @@ test_usize_t_overflow (xd3_stream *stream, int unused)
 }
 
 static int
+test_alloc_overflow (xd3_stream *stream, int unused)
+{
+  void *p;
+  usize_t r;
+
+  /* Macro boundary behavior: a zero operand never overflows, a unit
+   * operand never overflows, and the product is rejected exactly when
+   * it would exceed SIZE_MAX. */
+  if (XD3_MUL_SIZE_OVERFLOW (0, SIZE_MAX)) { goto fail; }
+  if (XD3_MUL_SIZE_OVERFLOW (SIZE_MAX, 0)) { goto fail; }
+  if (XD3_MUL_SIZE_OVERFLOW (1, SIZE_MAX)) { goto fail; }
+  if (XD3_MUL_SIZE_OVERFLOW (SIZE_MAX, 1)) { goto fail; }
+  if (XD3_MUL_SIZE_OVERFLOW (SIZE_MAX / 2, 2)) { goto fail; }
+  if (! XD3_MUL_SIZE_OVERFLOW (SIZE_MAX, 2)) { goto fail; }
+  if (! XD3_MUL_SIZE_OVERFLOW (2, SIZE_MAX)) { goto fail; }
+  if (! XD3_MUL_SIZE_OVERFLOW ((SIZE_MAX / 2) + 1, 2)) { goto fail; }
+
+  /* The core allocator must refuse an overflowing request without
+   * calling malloc.  These operands wrap to a small product when the
+   * guard is absent, so an unguarded malloc would succeed and return a
+   * dangerously undersized buffer; the guard must return NULL instead.
+   * A valid request must still be satisfied. */
+  if (__xd3_alloc_func (NULL, (SIZE_MAX / 2) + 2, 2) != NULL) { goto fail; }
+  p = __xd3_alloc_func (NULL, 16, 4);
+  if (p == NULL) { goto fail; }
+  free (p);
+
+#if XD3_MAIN
+  /* The CLI allocator shares the same guard. */
+  if (main_alloc (NULL, (SIZE_MAX / 2) + 2, 2) != NULL) { goto fail; }
+  p = main_alloc (NULL, 16, 4);
+  if (p == NULL) { goto fail; }
+  main_free1 (NULL, p);
+#endif
+
+  /* xd3_round_blksize must never return a value smaller than the
+   * requested size, including at the top of the usize_t range where
+   * rounding up would otherwise wrap. */
+  if (xd3_round_blksize (0, XD3_ALLOCSIZE) != 0) { goto fail; }
+  if (xd3_round_blksize (XD3_ALLOCSIZE, XD3_ALLOCSIZE) != XD3_ALLOCSIZE)
+    { goto fail; }
+  if (xd3_round_blksize (1, XD3_ALLOCSIZE) != XD3_ALLOCSIZE) { goto fail; }
+  if (xd3_round_blksize (XD3_ALLOCSIZE + 1, XD3_ALLOCSIZE) !=
+      2 * XD3_ALLOCSIZE) { goto fail; }
+
+  r = xd3_round_blksize (USIZE_T_MAX, XD3_ALLOCSIZE);
+  if (r < USIZE_T_MAX) { goto fail; }
+
+  r = xd3_round_blksize (USIZE_T_MAX - 1, XD3_ALLOCSIZE);
+  if (r < USIZE_T_MAX - 1) { goto fail; }
+
+  /* A zero blocksize must not corrupt the arithmetic. */
+  if (xd3_round_blksize (123, 0) != 123) { goto fail; }
+
+  return 0;
+
+ fail:
+  stream->msg = "alloc overflow guard failed";
+  return XD3_INTERNAL;
+}
+
+static int
 test_forward_match (xd3_stream *stream, int unused)
 {
   usize_t i;
@@ -2996,6 +3058,7 @@ int xd3_selftest (void)
   DO_TEST (encode_decode_uint32_t, 0, 0);
   DO_TEST (encode_decode_uint64_t, 0, 0);
   DO_TEST (usize_t_overflow, 0, 0);
+  DO_TEST (alloc_overflow, 0, 0);
   DO_TEST (checksum_step, 0, 0);
   DO_TEST (forward_match, 0, 0);
   DO_TEST (address_cache, 0, 0);

--- a/xdelta3/xdelta3.c
+++ b/xdelta3/xdelta3.c
@@ -1040,21 +1040,38 @@ xd3_xoff_roundup (xoff_t x)
 static usize_t
 xd3_round_blksize (usize_t sz, usize_t blksz)
 {
-  usize_t mod = sz & (blksz-1);
+  usize_t mod;
+  usize_t add;
 
   XD3_ASSERT (xd3_check_pow2 (blksz, NULL) == 0);
+
+  /* A zero blocksize would underflow the mask below; leave sz
+   * unchanged rather than corrupt the arithmetic. */
+  if (blksz == 0)
+    {
+      return sz;
+    }
+
+  mod = sz & (blksz-1);
 
   if (mod == 0)
     {
       return sz;
     }
 
-  if (sz > USIZE_T_MAXBLKSZ)
+  add = blksz - mod;
+
+  /* Rounding up must never wrap past USIZE_T_MAX.  A wrapped result
+   * would be smaller than sz and cause the caller to under-allocate.
+   * When the rounded value would overflow, return sz, which is itself
+   * a valid size and the largest we can guarantee is not smaller than
+   * requested. */
+  if (USIZE_T_OVERFLOW (sz, add))
     {
-      return USIZE_T_MAXBLKSZ;
+      return sz;
     }
 
-  return sz + (blksz - mod);
+  return sz + add;
 }
 
 /***********************************************************************
@@ -1392,6 +1409,10 @@ xd3_decode_address (xd3_stream *stream, usize_t here,
 static void*
 __xd3_alloc_func (void* opaque, size_t items, usize_t size)
 {
+  if (XD3_MUL_SIZE_OVERFLOW (items, size))
+    {
+      return NULL;
+    }
   return malloc (items * (size_t) size);
 }
 


### PR DESCRIPTION
Discussed in #232. Ubuntu's main-inclusion security review flagged several allocation multiplications with no overflow guard. A wrapped product yields an undersized buffer and a subsequent heap overflow. This adds defense-in-depth so the invariant holds by construction rather than by the distance of current callers from the overflow boundary.

  * Add XD3_MUL_SIZE_OVERFLOW, a size_t multiplication-overflow guard.
  * __xd3_alloc_func and main_alloc return NULL on overflow; xd3_alloc already maps NULL to "out of memory", and callers map it to ENOMEM.
  * setup_environment now checks both malloc results and guards the argv size multiply, falling back to the unmodified command line.
  * xd3_round_blksize no longer wraps when rounding up near USIZE_T_MAX; it returns a value that is never smaller than the requested size, and tolerates a zero blocksize.

Add test_alloc_overflow to the built-in suite. It exercises the macro boundaries, asserts both allocators reject a request that would wrap to a small product, and asserts xd3_round_blksize never returns less than the requested size. Verified to fail when any guard is removed.

Fixes #232