### PR TITLE
Warn on missing window checksum

### DIFF
--- a/xdelta3/xdelta3-decode.h
+++ b/xdelta3/xdelta3-decode.h
@@ -796,7 +796,8 @@ xd3_decode_emit (xd3_stream *stream)
 
       if (a32 != stream->dec_adler32)
 	{
-	  stream->msg = "target window checksum mismatch";
+	  stream->msg = "target window checksum mismatch: the supplied "
+	    "source likely does not match the one used to create this patch";
 	  return XD3_INVALID_INPUT;
 	}
     }

--- a/xdelta3/xdelta3-main.h
+++ b/xdelta3/xdelta3-main.h
@@ -277,6 +277,7 @@ static char*           program_name = NULL;
 static uint8_t*        appheader_used = NULL;
 static uint8_t*        main_bdata = NULL;
 static usize_t         main_bsize = 0;
+static int             main_warned_no_checksum = 0;
 
 /* Hacks for VCDIFF tools, recode command. */
 static int allow_fake_source = 0;
@@ -418,6 +419,7 @@ reset_defaults(void)
   appheader_used = NULL;
   main_bdata = NULL;
   main_bsize = 0;
+  main_warned_no_checksum = 0;
   allow_fake_source = 0;
   option_smatch_config = NULL;
 
@@ -3381,6 +3383,19 @@ main_input (xd3_cmd     cmd,
 
 	case XD3_WINFINISH:
 	  {
+	    /* Warn loudly, once, if a delta being decoded carries no
+	       integrity checksum, since a wrong source can then silently
+	       produce corrupt output. */
+	    if (cmd == CMD_DECODE && option_use_checksum &&
+		! option_quiet && ! main_warned_no_checksum &&
+		(stream.dec_win_ind & VCD_ADLER32) == 0)
+	      {
+		main_warned_no_checksum = 1;
+		XPR(NT "WARNING: this delta has no integrity checksum; "
+		    "the decoded output cannot be verified and a wrong "
+		    "source may silently produce corrupt output\n");
+	      }
+
 	    if (IS_ENCODE (cmd) || cmd == CMD_DECODE || cmd == CMD_RECODE)
 	      {
 		if (! option_quiet && IS_ENCODE (cmd) &&

--- a/xdelta3/xdelta3.c
+++ b/xdelta3/xdelta3.c
@@ -3411,6 +3411,9 @@ xd3_process_memory (int            is_encode,
 
   if (is_encode)
     {
+      /* The convenience encoder always emits a per-window checksum so
+	 decoders can detect a wrong source or a corrupt delta. */
+      config.flags |= XD3_ADLER32;
       config.winsize = xd3_min(input_size, (usize_t) XD3_DEFAULT_WINSIZE);
       config.sprevsz = xd3_pow2_roundup (config.winsize);
     }


### PR DESCRIPTION
Address the silent error condition: the per-window output checksum already detects a wrong source, but only when the delta carries one and the decoder is told to verify. Close the two ways that silently fails to happen.

- xd3_process_memory: the convenience encoder now always sets XD3_ADLER32 so xd3_encode_memory deltas carry a per-window checksum.
- main_input: on decode, warn loudly once (respecting -q) when a delta has no integrity checksum, since a wrong source can then silently corrupt output. This warns, it does not refuse.
- xd3_decode_input: make the checksum-mismatch message name the likely cause, that the supplied source does not match the one used to create the patch.