### PR TITLE
       Add armor mode: BLAKE3 whole-file verification via app-header

### DIFF
--- a/xdelta3/CMakeLists.txt
+++ b/xdelta3/CMakeLists.txt
@@ -22,6 +22,14 @@ set_property(CACHE XD3_LZMA_MODE PROPERTY STRINGS auto on off)
 
 option(XD3_WERROR "Treat compiler warnings as errors for the core targets" OFF)
 
+# Armor mode: whole-file BLAKE3 verification carried in the VCDIFF app-header.
+# When ON, the official BLAKE3 C library is fetched (pinned tag) and linked into
+# the xdelta3 command-line tool.  When OFF, armor is compiled out and the tool
+# behaves as if -a (disable armor) were always given.
+option(XD3_ARMOR "Enable armor mode (BLAKE3 whole-file verification)" ON)
+set(XD3_BLAKE3_TAG "1.8.5" CACHE STRING
+  "BLAKE3 release tag to fetch for armor mode")
+
 include(CheckTypeSize)
 include(CheckIncludeFile)
 include(CheckCSourceRuns)
@@ -142,6 +150,27 @@ function(xd3_configure_target target)
 endfunction()
 
 # ---------------------------------------------------------------------------
+# BLAKE3 (armor mode).  Fetched from the official repository, pinned to a
+# release tag so upstream security fixes are taken by bumping XD3_BLAKE3_TAG.
+# The C library lives in the repo's c/ subdirectory and exports the `blake3`
+# target.
+# ---------------------------------------------------------------------------
+set(XD3_ARMOR_LIBRARIES "")
+if(XD3_ARMOR)
+  include(FetchContent)
+  FetchContent_Declare(blake3
+    GIT_REPOSITORY https://github.com/BLAKE3-team/BLAKE3.git
+    GIT_TAG ${XD3_BLAKE3_TAG}
+    GIT_SHALLOW TRUE
+    SOURCE_SUBDIR c)
+  FetchContent_MakeAvailable(blake3)
+  set(XD3_ARMOR_LIBRARIES blake3)
+  message(STATUS "xdelta3: armor mode enabled (BLAKE3 ${XD3_BLAKE3_TAG})")
+else()
+  message(STATUS "xdelta3: armor mode disabled")
+endif()
+
+# ---------------------------------------------------------------------------
 # xdelta3 - the command-line tool / library driver
 # ---------------------------------------------------------------------------
 add_executable(xdelta3 xdelta3.c)
@@ -151,6 +180,10 @@ target_compile_definitions(xdelta3 PRIVATE
   ${XD3_PLATFORM_DEFS})
 target_compile_options(xdelta3 PRIVATE ${XD3_WERROR_FLAGS})
 target_link_libraries(xdelta3 PRIVATE ${XD3_LZMA_LIBRARIES})
+if(XD3_ARMOR)
+  target_compile_definitions(xdelta3 PRIVATE XD3_ARMOR=1)
+  target_link_libraries(xdelta3 PRIVATE ${XD3_ARMOR_LIBRARIES})
+endif()
 
 # ---------------------------------------------------------------------------
 # xdelta3decode - minimal decode-only build (no encoder, no secondary comp.)

--- a/xdelta3/README.md
+++ b/xdelta3/README.md
@@ -40,6 +40,38 @@ liblzma is autodetected.  Force it on or off with `-DXD3_LZMA_MODE=on`
 or `-DXD3_LZMA_MODE=off`.  On Homebrew systems, point CMake at the
 prefix with `-DCMAKE_PREFIX_PATH="$(brew --prefix)"`.
 
+Armor mode (whole-file verification)
+------------------------------------
+
+By default the `xdelta3` tool builds with armor mode, which embeds BLAKE3
+digests of the source and target files in the VCDIFF application header
+(using a `name#blake3` syntax) and verifies them:
+
+  * Encode reads the source and target in full to compute their digests and
+    therefore requires both to be seekable (regular) files.
+  * Decode verifies the source up front, before applying, and verifies the
+    reconstructed target afterward.  A wrong source fails fast with a clear
+    message instead of a late, ambiguous window-checksum error.
+  * If the supplied source already matches the delta's *target* digest (the
+    patch is already applied), decode reports "already up to date" and exits
+    with status 2.
+  * If the source is a stream (not seekable) it cannot be verified, so decode
+    prints a warning and proceeds.
+  * The digests cover the logical (decompressed) content xdelta3 processes,
+    not the raw on-disk bytes, so armor composes correctly with external
+    input decompression and output recompression.
+  * `merge` verifies an armored chain of deltas when every input is armored.
+
+Pass `-a` to disable armor: this restores the legacy application-header
+format and the non-seekable streaming behavior (e.g. for piped input).
+Legacy xdelta3 builds read the armored names as literal filenames, so they
+must apply such deltas with explicit `-s`/output filenames.
+
+BLAKE3 is fetched at configure time from its official repository, pinned to
+a release tag (`-DXD3_BLAKE3_TAG=...`).  Disable armor entirely at build time
+with `-DXD3_ARMOR=OFF`, which removes the BLAKE3 dependency and makes the
+tool behave as if `-a` were always given.
+
 Testing
 -------
 

--- a/xdelta3/go/regtest.go
+++ b/xdelta3/go/regtest.go
@@ -42,11 +42,11 @@ func (c Config) smokeTest(t *xdelta.TestGroup, p xdelta.Program) {
 	target := "Hello world!"
 	source := "Hello world, nice to meet you!"
 
-	enc, err := t.Exec("encode", p, true, []string{"-e"})
+	enc, err := t.Exec("encode", p, true, []string{"-a", "-e"})
 	if err != nil {
 		t.Panic(err)
 	}
-	dec, err := t.Exec("decode", p, true, []string{"-d"})
+	dec, err := t.Exec("decode", p, true, []string{"-a", "-d"})
 	if err != nil {
 		t.Panic(err)
 	}
@@ -176,7 +176,7 @@ func (cfg Config) datasetTest(t *xdelta.TestGroup, p, q xdelta.Program, xdataset
 
 func (pt *PairTest) datasetPairTest(t *xdelta.TestGroup, meanSize int64) {
 	cfg := pt.Config
-	eargs := []string{"-e", fmt.Sprint("-B", cfg.srcbuf_size), // "-q",
+	eargs := []string{"-a", "-e", fmt.Sprint("-B", cfg.srcbuf_size), // "-q",
 		fmt.Sprint("-W", cfg.window_size), "-s", pt.source,
 		"-I0", "-S", "none", pt.target}
 	enc, err := t.Exec("encode", pt.program, false, eargs)
@@ -184,7 +184,7 @@ func (pt *PairTest) datasetPairTest(t *xdelta.TestGroup, meanSize int64) {
 		t.Panic(err)
 	}
 
-	dargs := []string{"-dc", fmt.Sprint("-B", cfg.srcbuf_size), //"-q",
+	dargs := []string{"-a", "-dc", fmt.Sprint("-B", cfg.srcbuf_size), //"-q",
 		fmt.Sprint("-W", cfg.window_size), "-s", pt.source,
 		"-S", "none"}
 
@@ -214,14 +214,14 @@ func (pt *PairTest) datasetPairTest(t *xdelta.TestGroup, meanSize int64) {
 }
 
 func (cfg Config) offsetTest(t *xdelta.TestGroup, p xdelta.Program, offset, length int64) {
-	eargs := []string{"-e", "-0", fmt.Sprint("-B", cfg.srcbuf_size), "-q",
+	eargs := []string{"-a", "-e", "-0", fmt.Sprint("-B", cfg.srcbuf_size), "-q",
 		fmt.Sprint("-W", cfg.window_size)}
 	enc, err := t.Exec("encode", p, true, eargs)
 	if err != nil {
 		t.Panic(err)
 	}
 	
-	dargs := []string{"-d", fmt.Sprint("-B", cfg.srcbuf_size), "-q",
+	dargs := []string{"-a", "-d", fmt.Sprint("-B", cfg.srcbuf_size), "-q",
 		fmt.Sprint("-W", cfg.window_size)}
 	dec, err := t.Exec("decode", p, true, dargs)
 	if err != nil {

--- a/xdelta3/xdelta3-main.h
+++ b/xdelta3/xdelta3-main.h
@@ -2987,10 +2987,11 @@ static void main_get_appheader(xd3_stream *stream, main_file *ifile,
     parsed[place++] = start;
 
 #if XD3_ARMOR
-    /* Strip armored "name#<64hex>" digests from the name fields and remember
-     * them for verification.  Done before the params are consumed so default
-     * filenames do not include the digest. */
-    if (!option_no_armor) {
+    /* Strip armored "name#<64hex>" digests from the name fields so default
+     * filenames never include the digest.  This is done even under -a
+     * (option_no_armor): -a means "do not verify", not "treat the delta as
+     * legacy".  Only record the digests for verification when armor is on. */
+    {
       const char *th = NULL;
       const char *sh = NULL;
       if (place == 2 || place == 4) {
@@ -2999,13 +3000,15 @@ static void main_get_appheader(xd3_stream *stream, main_file *ifile,
       if (place == 4) {
         sh = main_armor_split(parsed[2]);
       }
-      if (th != NULL) {
-        strcpy(armor_expect_target, th);
-        armor_have_target = 1;
-      }
-      if (sh != NULL) {
-        strcpy(armor_expect_source, sh);
-        armor_have_source = 1;
+      if (!option_no_armor) {
+        if (th != NULL) {
+          strcpy(armor_expect_target, th);
+          armor_have_target = 1;
+        }
+        if (sh != NULL) {
+          strcpy(armor_expect_source, sh);
+          armor_have_source = 1;
+        }
       }
     }
 #endif

--- a/xdelta3/xdelta3-main.h
+++ b/xdelta3/xdelta3-main.h
@@ -83,6 +83,26 @@ int xsnprintf_func(char *str, size_t n, const char *fmt, ...) {
 #define EXTERNAL_COMPRESSION 1
 #endif
 
+/* Armor mode: whole-file BLAKE3 verification carried in the app-header.  When
+ * compiled out (XD3_ARMOR=0) the -a/armor machinery is absent and the tool
+ * behaves as if armor were always disabled. */
+#ifndef XD3_ARMOR
+#define XD3_ARMOR 0
+#endif
+
+#if XD3_ARMOR
+#include <blake3.h>
+/* BLAKE3-256 rendered as lowercase hex, plus NUL. */
+#define XD3_BLAKE3_HEXLEN (2 * BLAKE3_OUT_LEN)
+#define XD3_BLAKE3_HEXBUF (XD3_BLAKE3_HEXLEN + 1)
+
+/* Distinct process exit code returned by decode when the supplied source
+ * already matches the delta's target digest, i.e. the patch is already
+ * applied / the source is already up to date.  Distinct from the generic
+ * failure code (1) so scripts can detect this case. */
+#define EXIT_ARMOR_UP_TO_DATE 2
+#endif
+
 #define PRINTHDR_SPECIAL -4378291
 
 /* The number of soft-config variables.  */
@@ -239,6 +259,15 @@ static int option_no_compress = 0;
 static int option_no_output = 0; /* do not write output */
 static const char *option_source_filename = NULL;
 
+/* Armor mode (BLAKE3 whole-file verification) is on by default; -a disables
+ * it.  When armor is compiled out (XD3_ARMOR=0) this is forced on so the rest
+ * of the code takes the no-armor path. */
+#if XD3_ARMOR
+static int option_no_armor = 0;
+#else
+static int option_no_armor = 1;
+#endif
+
 static int option_level = XD3_DEFAULT_LEVEL;
 static usize_t option_iopt_size = XD3_DEFAULT_IOPT_SIZE;
 static usize_t option_winsize = XD3_DEFAULT_WINSIZE;
@@ -280,6 +309,29 @@ static xd3_stream *recode_stream = NULL;
 /* merge_stream is used by merge commands for storing the source encoding */
 static xd3_stream *merge_stream = NULL;
 
+#if XD3_ARMOR
+/* Armor verification state for the current decode/apply operation.  The
+ * expected hashes are parsed from the armored app-header; the target hasher
+ * accumulates the reconstructed output for after-the-fact verification. */
+static char armor_expect_source[XD3_BLAKE3_HEXBUF];
+static char armor_expect_target[XD3_BLAKE3_HEXBUF];
+static int armor_have_source = 0;   /* expected source hash present */
+static int armor_have_target = 0;   /* expected target hash present */
+static int armor_target_active = 0; /* feed output to the target hasher */
+static blake3_hasher armor_target_hasher;
+
+/* Armor merge-chain verification state, accumulated as the chain of deltas is
+ * read in order (the -m arguments first, then the final input). */
+static int armor_merge_count = 0;
+static int armor_merge_all = 1;    /* every link seen so far is armored */
+static int armor_merge_broken = 0; /* a chain-link mismatch was detected */
+static int armor_merge_have_first_source = 0;
+static char armor_merge_first_source[XD3_BLAKE3_HEXBUF];
+static int armor_merge_have_prev_target = 0;
+static char armor_merge_prev_target[XD3_BLAKE3_HEXBUF];
+static int armor_merge_have_last_target = 0;
+static char armor_merge_last_target[XD3_BLAKE3_HEXBUF];
+#endif
 /* This array of compressor types is compiled even if EXTERNAL_COMPRESSION is
  * false just so the program knows the mapping of IDENT->NAME. */
 static main_extcomp extcomp_types[] = {
@@ -406,6 +458,11 @@ static void reset_defaults(void) {
 
   option_use_appheader = 1;
   option_use_checksum = 1;
+#if XD3_ARMOR
+  option_no_armor = 0;
+#else
+  option_no_armor = 1;
+#endif
 #if EXTERNAL_COMPRESSION
   option_force2 = 0;
   option_decompress_inputs = 1;
@@ -1137,6 +1194,15 @@ static int main_write_output(xd3_stream *stream, main_file *ofile) {
   IF_DEBUG1(DP(RINT "[main] write(%s) %" W "u\n bytes", ofile->filename,
                stream->avail_out));
 
+#if XD3_ARMOR
+  /* Accumulate the reconstructed target for armor verification.  Done before
+   * the option_no_output early return so -J still verifies. */
+  if (armor_target_active && stream->avail_out > 0) {
+    blake3_hasher_update(&armor_target_hasher, stream->next_out,
+                         stream->avail_out);
+  }
+#endif
+
   if (option_no_output) {
     return 0;
   }
@@ -1767,6 +1833,34 @@ static int main_merge_output(xd3_stream *stream, main_file *ofile) {
     xd3_set_appheader(recode_stream, option_appheader,
                       (usize_t)strlen((char *)option_appheader));
   }
+#if XD3_ARMOR
+  /* Armored merge-chain verification and re-arming of the merged output. */
+  else if (option_use_appheader != 0 && !option_no_armor) {
+    if (armor_merge_broken) {
+      XPR(NT "armor: refusing to merge a broken armored chain; "
+             "use -a to disable armor\n");
+      return XD3_INVALID_INPUT;
+    }
+    if (armor_merge_count > 0 && armor_merge_all &&
+        armor_merge_have_first_source && armor_merge_have_last_target) {
+      /* Re-arm with the first link's source and the last link's target.  The
+       * merged delta has no associated filenames, so the name fields are just
+       * the digests. */
+      static uint8_t merged_appheader[2 * XD3_BLAKE3_HEXBUF + 8];
+      snprintf_func((char *)merged_appheader, sizeof(merged_appheader),
+                    "-#%s//-#%s/", armor_merge_last_target,
+                    armor_merge_first_source);
+      xd3_set_appheader(recode_stream, merged_appheader,
+                        (usize_t)strlen((char *)merged_appheader));
+      if (option_verbose) {
+        XPR(NT "armor: merged chain verified (%d links)\n", armor_merge_count);
+      }
+    } else if (armor_merge_count > 0 && !option_quiet) {
+      XPR(NT "armor: merged delta is not armored "
+             "(not all inputs carried digests)\n");
+    }
+  }
+#endif
 
   /* Enter the ENC_INPUT state and bypass the next_in == NULL test
    * and (leftover) input buffering logic. */
@@ -2444,6 +2538,254 @@ static const main_extcomp *main_get_compressor(const char *ident) {
  APPLICATION HEADER
  *******************************************************************/
 
+#if XD3_ARMOR
+/* Render a BLAKE3-256 digest as lowercase hex with a trailing NUL. */
+static void main_armor_hex(const uint8_t digest[BLAKE3_OUT_LEN],
+                           char out[XD3_BLAKE3_HEXBUF]) {
+  static const char hexdig[] = "0123456789abcdef";
+  int i;
+  for (i = 0; i < BLAKE3_OUT_LEN; i += 1) {
+    out[2 * i] = hexdig[(digest[i] >> 4) & 0xf];
+    out[2 * i + 1] = hexdig[digest[i] & 0xf];
+  }
+  out[XD3_BLAKE3_HEXLEN] = 0;
+}
+
+/* True iff s is exactly XD3_BLAKE3_HEXLEN lowercase hex digits then NUL. */
+static int main_armor_is_hex(const char *s) {
+  usize_t i;
+  for (i = 0; i < XD3_BLAKE3_HEXLEN; i += 1) {
+    char c = s[i];
+    if (!((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'))) {
+      return 0;
+    }
+  }
+  return s[XD3_BLAKE3_HEXLEN] == 0;
+}
+
+/* If the app-header name field is in armored "name#<64hex>" form, NUL-
+ * terminate the name at the last '#' and return a pointer to the hash;
+ * otherwise return NULL and leave name unchanged.  Filenames may contain
+ * '#', so the split is on the LAST '#' and the suffix must be valid hex. */
+static const char *main_armor_split(char *name) {
+  char *hash = strrchr(name, '#');
+  if (hash != NULL && main_armor_is_hex(hash + 1)) {
+    *hash = 0;
+    return hash + 1;
+  }
+  return NULL;
+}
+
+/* Compute the BLAKE3-256 over the *logical* bytes of a file, i.e. the bytes
+ * xdelta actually processes after any external decompression.  Hashing the
+ * logical (decompressed) content -- rather than the raw on-disk bytes -- makes
+ * armor independent of the exact compressed representation: decompression is
+ * deterministic, whereas recompression is not, so the decoder can reproduce
+ * this hash from the reconstructed content.  Armor requires a seekable
+ * (regular) file because the delta operation reads the same input a second
+ * time.  "type" names the input for messages.
+ *
+ * If "nonseekable" is non-NULL it receives 1 when the file is a stream
+ * (FIFO/pipe) that cannot be hashed, and the function returns 0 without a
+ * hash -- the caller decides whether to warn or fail.  If "nonseekable" is
+ * NULL, a non-seekable file is a hard error. */
+static int main_armor_hash_file(const char *filename, const char *type,
+                                char out_hex[XD3_BLAKE3_HEXBUF],
+                                int *nonseekable) {
+  main_file f;
+  blake3_hasher hasher;
+  uint8_t digest[BLAKE3_OUT_LEN];
+  uint8_t *buf = NULL;
+  xoff_t fsize = 0;
+  size_t bufsz = XD3_ALLOCSIZE;
+  int ret = 0;
+  int read_ret = 0;
+#if EXTERNAL_COMPRESSION
+  int subprocs_before = num_subprocs;
+  int saved_quiet = option_quiet;
+#endif
+
+  if (nonseekable != NULL) {
+    *nonseekable = 0;
+  }
+
+  main_file_init(&f);
+  /* RD_FIRST (and *not* RD_NONEXTERNAL) so the same external-decompression
+   * detection used by the real read applies here. */
+  f.flags = RD_FIRST;
+
+  if ((ret = main_file_open(&f, filename, XO_READ))) {
+    main_file_cleanup(&f);
+    return ret;
+  }
+
+  if (main_file_stat(&f, &fsize) != 0) {
+    main_file_close(&f);
+    main_file_cleanup(&f);
+    if (nonseekable != NULL) {
+      *nonseekable = 1;
+      return 0;
+    }
+    XPR(NT "armor requires a seekable %s: %s\n", type, filename);
+    return XD3_INVALID_INPUT;
+  }
+
+  if ((buf = (uint8_t *)main_malloc(bufsz)) == NULL) {
+    main_file_close(&f);
+    main_file_cleanup(&f);
+    return ENOMEM;
+  }
+
+  blake3_hasher_init(&hasher);
+
+#if EXTERNAL_COMPRESSION
+  /* Suppress the duplicate "externally compressed input" notice; the real
+   * read of this input prints it. */
+  option_quiet = 1;
+#endif
+
+  for (;;) {
+    size_t nread = 0;
+    if ((read_ret = main_read_primary_input(&f, buf, bufsz, &nread))) {
+      break;
+    }
+    if (nread == 0) {
+      break;
+    }
+    blake3_hasher_update(&hasher, buf, nread);
+  }
+
+#if EXTERNAL_COMPRESSION
+  option_quiet = saved_quiet;
+#endif
+
+  main_free(buf);
+  main_file_close(&f);
+  main_file_cleanup(&f);
+
+#if EXTERNAL_COMPRESSION
+  /* Reap any decompression subprocesses forked by this pass so they do not
+   * accumulate against MAX_SUBPROCS during the real operation. */
+  while (num_subprocs > subprocs_before) {
+    num_subprocs -= 1;
+    if (ext_subprocs[num_subprocs]) {
+      int wret = main_waitpid_check(ext_subprocs[num_subprocs]);
+      if (read_ret == 0 && wret != 0) {
+        read_ret = wret;
+      }
+      ext_subprocs[num_subprocs] = 0;
+    }
+  }
+#endif
+
+  ret = read_ret;
+
+  if (ret != 0) {
+    return ret;
+  }
+
+  blake3_hasher_finalize(&hasher, digest, sizeof(digest));
+  main_armor_hex(digest, out_hex);
+  return 0;
+}
+
+/* Parse a raw (read-only) app-header buffer and extract the armored source and
+ * target digests, if present.  The buffer is copied because parsing is
+ * destructive (it splits on '/' and '#'). */
+static void main_armor_parse_appheader(const uint8_t *apphead, usize_t sz,
+                                       int *have_source, char *source,
+                                       int *have_target, char *target) {
+  char *copy;
+  char *start;
+  char *slash;
+  int place = 0;
+  char *parsed[4];
+
+  *have_source = 0;
+  *have_target = 0;
+
+  if (apphead == NULL || sz == 0) {
+    return;
+  }
+
+  if ((copy = (char *)main_malloc(sz + 1)) == NULL) {
+    return;
+  }
+  memcpy(copy, apphead, sz);
+  copy[sz] = 0;
+
+  memset(parsed, 0, sizeof(parsed));
+  start = copy;
+  while ((slash = strchr(start, '/')) != NULL && place < 3) {
+    *slash = 0;
+    parsed[place++] = start;
+    start = slash + 1;
+  }
+  parsed[place++] = start;
+
+  if (place == 2 || place == 4) {
+    const char *th = main_armor_split(parsed[0]);
+    if (th != NULL) {
+      strcpy(target, th);
+      *have_target = 1;
+    }
+  }
+  if (place == 4) {
+    const char *sh = main_armor_split(parsed[2]);
+    if (sh != NULL) {
+      strcpy(source, sh);
+      *have_source = 1;
+    }
+  }
+
+  main_free(copy);
+}
+
+/* Record one delta of a merge chain (called in chain order) and verify that
+ * its source digest matches the previous link's target digest. */
+static void main_armor_merge_link(const uint8_t *apphead, usize_t sz) {
+  int have_source = 0;
+  int have_target = 0;
+  char source[XD3_BLAKE3_HEXBUF];
+  char target[XD3_BLAKE3_HEXBUF];
+  int idx = armor_merge_count;
+
+  main_armor_parse_appheader(apphead, sz, &have_source, source, &have_target,
+                             target);
+  armor_merge_count += 1;
+
+  if (!have_source || !have_target) {
+    /* A link missing either digest cannot be fully verified or re-armored. */
+    if (idx != 0 || !have_target) {
+      armor_merge_all = 0;
+    }
+  }
+
+  if (idx == 0) {
+    if (have_source) {
+      strcpy(armor_merge_first_source, source);
+      armor_merge_have_first_source = 1;
+    }
+  } else if (armor_merge_have_prev_target && have_source) {
+    if (strcmp(armor_merge_prev_target, source) != 0) {
+      armor_merge_broken = 1;
+      XPR(NT "armor: broken armored chain at merge link %d\n", idx);
+      XPR(NT "  previous target %s\n", armor_merge_prev_target);
+      XPR(NT "  this source     %s\n", source);
+    }
+  }
+
+  if (have_target) {
+    strcpy(armor_merge_prev_target, target);
+    armor_merge_have_prev_target = 1;
+    strcpy(armor_merge_last_target, target);
+    armor_merge_have_last_target = 1;
+  } else {
+    armor_merge_have_prev_target = 0;
+  }
+}
+#endif /* XD3_ARMOR */
+
 #if XD3_ENCODER
 static const char *main_apphead_string(const char *x) {
   const char *y;
@@ -2479,6 +2821,17 @@ static int main_set_appheader(xd3_stream *stream, main_file *input,
     const char *sname;
     const char *scomp;
     usize_t len;
+#if XD3_ARMOR
+    /* Armored name fields carry "name#<64hex>".  Computed below when armor
+     * is enabled (the default). */
+    char thash[XD3_BLAKE3_HEXBUF];
+    char shash[XD3_BLAKE3_HEXBUF];
+    const char *tsep = "";
+    const char *thashstr = "";
+    const char *ssep = "";
+    const char *shashstr = "";
+    int armor = !option_no_armor;
+#endif
 
     iname = main_apphead_string(input->filename);
     icomp = (input->compressor == NULL) ? "" : input->compressor->ident;
@@ -2492,11 +2845,51 @@ static int main_set_appheader(xd3_stream *stream, main_file *input,
       sname = scomp = "";
     }
 
+#if XD3_ARMOR
+    if (armor) {
+      int ret;
+      /* The target is the encoder input; the source is the -s file.  Both
+       * must be seekable regular files so they can be hashed up front. */
+      if (input->filename == NULL) {
+        XPR(NT "armor requires a seekable target; use -a to disable armor\n");
+        return XD3_INVALID_INPUT;
+      }
+      if ((ret =
+               main_armor_hash_file(input->filename, "target", thash, NULL))) {
+        return ret;
+      }
+      tsep = "#";
+      thashstr = thash;
+      len += (usize_t)(strlen(tsep) + strlen(thashstr));
+
+      if (sfile->filename != NULL) {
+        if ((ret = main_armor_hash_file(sfile->filename, "source", shash,
+                                        NULL))) {
+          return ret;
+        }
+        ssep = "#";
+        shashstr = shash;
+        len += (usize_t)(strlen(ssep) + strlen(shashstr));
+      }
+    }
+#endif
+
     if ((appheader_used = (uint8_t *)main_malloc(len)) == NULL) {
       return ENOMEM;
     }
 
-    if (sfile->filename == NULL) {
+#if XD3_ARMOR
+    if (armor) {
+      if (sfile->filename == NULL) {
+        snprintf_func((char *)appheader_used, len, "%s%s%s/%s", iname, tsep,
+                      thashstr, icomp);
+      } else {
+        snprintf_func((char *)appheader_used, len, "%s%s%s/%s/%s%s%s/%s", iname,
+                      tsep, thashstr, icomp, sname, ssep, shashstr, scomp);
+      }
+    } else
+#endif
+        if (sfile->filename == NULL) {
       snprintf_func((char *)appheader_used, len, "%s/%s", iname, icomp);
     } else {
       snprintf_func((char *)appheader_used, len, "%s/%s/%s/%s", iname, icomp,
@@ -2592,6 +2985,30 @@ static void main_get_appheader(xd3_stream *stream, main_file *ifile,
     }
 
     parsed[place++] = start;
+
+#if XD3_ARMOR
+    /* Strip armored "name#<64hex>" digests from the name fields and remember
+     * them for verification.  Done before the params are consumed so default
+     * filenames do not include the digest. */
+    if (!option_no_armor) {
+      const char *th = NULL;
+      const char *sh = NULL;
+      if (place == 2 || place == 4) {
+        th = main_armor_split(parsed[0]);
+      }
+      if (place == 4) {
+        sh = main_armor_split(parsed[2]);
+      }
+      if (th != NULL) {
+        strcpy(armor_expect_target, th);
+        armor_have_target = 1;
+      }
+      if (sh != NULL) {
+        strcpy(armor_expect_source, sh);
+        armor_have_source = 1;
+      }
+    }
+#endif
 
     /* First take the output parameters. */
     if (place == 2 || place == 4) {
@@ -2736,6 +3153,13 @@ static int main_input(xd3_cmd cmd, main_file *ifile, main_file *ofile,
   do_src_fifo = 0;
 
   start_time = get_millisecs_now();
+
+#if XD3_ARMOR
+  /* Reset per-operation armor verification state. */
+  armor_have_source = 0;
+  armor_have_target = 0;
+  armor_target_active = 0;
+#endif
 
   if (option_use_checksum) {
     stream_flags |= XD3_ADLER32;
@@ -2958,7 +3382,75 @@ static int main_input(xd3_cmd cmd, main_file *ifile, main_file *ofile,
             (ret = main_set_source(&stream, cmd, sfile, &source))) {
           return EXIT_FAILURE;
         }
+
+#if XD3_ARMOR
+        /* Armor: verify the source up front, before applying anything, then
+         * arm the on-the-fly target hasher. */
+        if (armor_have_source) {
+          char got[XD3_BLAKE3_HEXBUF];
+          int nonseekable = 0;
+
+          if (sfile->filename == NULL) {
+            XPR(NT "armor: this delta requires a source but none was given; "
+                   "use -a to skip armor verification\n");
+            return EXIT_FAILURE;
+          }
+          if ((ret = main_armor_hash_file(sfile->filename, "source", got,
+                                          &nonseekable))) {
+            return EXIT_FAILURE;
+          }
+          if (nonseekable) {
+            /* A streaming (non-seekable) source cannot be read a second time
+             * to hash it, so armor cannot verify it.  Warn and proceed; the
+             * target is still verified on the fly. */
+            XPR(NT "WARNING: this delta is armored but the source is not "
+                   "seekable (streaming);\n");
+            XPR(NT "WARNING: the source cannot be verified.  Provide a "
+                   "seekable source file\n");
+            XPR(NT "WARNING: to verify it, or use -a to disable armor.\n");
+          } else if (strcmp(got, armor_expect_source) != 0) {
+            /* The source already matches the *target*: the patch is already
+             * applied / the source is up to date. */
+            if (armor_have_target && strcmp(got, armor_expect_target) == 0) {
+              XPR(NT "the source is already up to date: %s\n", sfile->filename);
+              XPR(NT "it already matches the target of this patch; "
+                     "nothing to do\n");
+              return EXIT_ARMOR_UP_TO_DATE;
+            }
+            XPR(NT "source file BLAKE3 mismatch: %s\n", sfile->filename);
+            XPR(NT "  expected %s\n", armor_expect_source);
+            XPR(NT "  actual   %s\n", got);
+            XPR(NT "the supplied source does not match the one used to build "
+                   "this patch\n");
+            return EXIT_FAILURE;
+          } else if (option_verbose) {
+            XPR(NT "armor: source verified (%s)\n", sfile->filename);
+          }
+        }
+        if (armor_have_target) {
+          blake3_hasher_init(&armor_target_hasher);
+          armor_target_active = 1;
+        }
+#endif
       }
+#if XD3_ARMOR
+      /* Record each delta of a merge chain (in chain order) for armored
+       * chain verification. */
+      if (!option_no_armor && (cmd == CMD_MERGE || cmd == CMD_MERGE_ARG)) {
+        uint8_t *apphead = NULL;
+        usize_t appheadsz = 0;
+        if (xd3_get_appheader(&stream, &apphead, &appheadsz) == 0) {
+          main_armor_merge_link(apphead, appheadsz);
+        } else {
+          main_armor_merge_link(NULL, 0);
+        }
+        if (armor_merge_broken) {
+          XPR(NT "armor: refusing to merge a broken armored chain; "
+                 "use -a to disable armor\n");
+          return EXIT_FAILURE;
+        }
+      }
+#endif
     }
     /* FALLTHROUGH */
     case XD3_WINSTART: {
@@ -3112,6 +3604,31 @@ done:
       return EXIT_FAILURE;
     }
   }
+
+#if XD3_ARMOR
+  /* Armor: verify the reconstructed target now that all output has been
+   * produced. */
+  if (armor_target_active) {
+    uint8_t digest[BLAKE3_OUT_LEN];
+    char got[XD3_BLAKE3_HEXBUF];
+
+    armor_target_active = 0;
+    blake3_hasher_finalize(&armor_target_hasher, digest, sizeof(digest));
+    main_armor_hex(digest, got);
+
+    if (strcmp(got, armor_expect_target) != 0) {
+      const char *oname =
+          (ofile != NULL && ofile->filename != NULL) ? ofile->filename : "-";
+      XPR(NT "target BLAKE3 mismatch after apply: %s\n", oname);
+      XPR(NT "  expected %s\n", armor_expect_target);
+      XPR(NT "  actual   %s\n", got);
+      return EXIT_FAILURE;
+    }
+    if (option_verbose) {
+      XPR(NT "armor: target verified\n");
+    }
+  }
+#endif
 
 #if EXTERNAL_COMPRESSION
   if ((ret = main_external_compression_finish())) {
@@ -3272,7 +3789,7 @@ int main(int argc, char **argv)
 #endif
 {
   static const char *flags =
-      "0123456789cdefhnqvDFJNORVs:m:B:C:E:I:L:O:M:P:W:A::S::";
+      "0123456789acdefhnqvDFJNORVs:m:B:C:E:I:L:O:M:P:W:A::S::";
   xd3_cmd cmd;
   main_file ifile;
   main_file ofile;
@@ -3497,6 +4014,9 @@ takearg:
     case 'n':
       option_use_checksum = 0;
       break;
+    case 'a':
+      option_no_armor = 1;
+      break;
     case 'N':
       option_no_compress = 1;
       break;
@@ -3638,6 +4158,18 @@ takearg:
   }
 
 #if VCDIFF_TOOLS
+#if XD3_ARMOR
+  /* Reset armor merge-chain state once for the whole merge operation (it must
+   * persist across the per-delta main_input calls). */
+  if (cmd == CMD_MERGE) {
+    armor_merge_count = 0;
+    armor_merge_all = 1;
+    armor_merge_broken = 0;
+    armor_merge_have_first_source = 0;
+    armor_merge_have_prev_target = 0;
+    armor_merge_have_last_target = 0;
+  }
+#endif
   if (cmd == CMD_MERGE && (ret = main_merge_arguments(&merge_order))) {
     goto cleanup;
   }
@@ -3762,6 +4294,10 @@ static int main_help(void) {
   XPR(NTR "   -D           disable external decompression (encode/decode)\n");
   XPR(NTR "   -R           disable external recompression (decode)\n");
   XPR(NTR "   -n           disable checksum (encode/decode)\n");
+#if XD3_ARMOR
+  XPR(NTR "   -a           disable armor (whole-file BLAKE3 verification,\n");
+  XPR(NTR "                on by default; requires a seekable source)\n");
+#endif
   XPR(NTR "   -C           soft config (encode, undocumented)\n");
   XPR(NTR "   -A [apphead] disable/provide application header (encode)\n");
   XPR(NTR "   -J           disable output (check/compute only)\n");

--- a/xdelta3/xdelta3-test.h
+++ b/xdelta3/xdelta3-test.h
@@ -2647,6 +2647,18 @@ static int test_armor(xd3_stream *stream, int ignore) {
     return ret;
   }
 
+  /* -a must still strip the digest from app-header default filenames: decode
+   * with -a and no -s relies on the embedded source name, which must resolve
+   * to the real file ("source") and not "source#<hash>". */
+  snprintf_func(buf, TESTBUFSIZE, "%s -q -f -a -d %s %s", program_name,
+                TEST_DELTA_FILE, TEST_RECON_FILE);
+  if ((ret = do_cmd(stream, buf))) {
+    return ret;
+  }
+  if ((ret = test_compare_files(TEST_TARGET_FILE, TEST_RECON_FILE))) {
+    return ret;
+  }
+
   /* -a encode produces a legacy app-header with no digest. */
   snprintf_func(buf, TESTBUFSIZE, "%s -q -f -a -e -s %s %s %s", program_name,
                 TEST_SOURCE_FILE, TEST_TARGET_FILE, TEST_DELTA_FILE);

--- a/xdelta3/xdelta3-test.h
+++ b/xdelta3/xdelta3-test.h
@@ -2145,13 +2145,13 @@ static int test_externally_compressed_io(xd3_stream *stream, int ignore) {
       continue;
     }
 
-    if ((ret = test_compressed_pipe(stream, ext, buf, "-cfq", "-dcfq", 1,
+    if ((ret = test_compressed_pipe(stream, ext, buf, "-cfqa", "-dcfqa", 1,
                                     "compression failed: identity pipe")) ||
         (ret = test_compressed_pipe(
-             stream, ext, buf, "-cfq", "-Rdcfq", 0,
+             stream, ext, buf, "-cfqa", "-Rdcfqa", 0,
              "compression failed: without recompression")) ||
         (ret = test_compressed_pipe(
-             stream, ext, buf, "-Dcfq", "-Rdcfq", 1,
+             stream, ext, buf, "-Dcfqa", "-Rdcfqa", 1,
              "compression failed: without decompression"))) {
       return ret;
     }
@@ -2211,7 +2211,7 @@ static int test_source_decompression(xd3_stream *stream, int ignore) {
 
   /* Now the two identical files are compressed.  Delta-encode the target,
    * with decompression. */
-  snprintf_func(buf, TESTBUFSIZE, "%s -e -vfq -s%s %s %s", program_name,
+  snprintf_func(buf, TESTBUFSIZE, "%s -a -e -vfq -s%s %s %s", program_name,
                 TEST_SOURCE_FILE, TEST_TARGET_FILE, TEST_DELTA_FILE);
   if ((ret = do_cmd(stream, buf))) {
     return ret;
@@ -2231,7 +2231,7 @@ static int test_source_decompression(xd3_stream *stream, int ignore) {
 
   /* Decode the delta file with recompression disabled, should get an
    * uncompressed file out. */
-  snprintf_func(buf, TESTBUFSIZE, "%s -v -dq -R -s%s %s %s", program_name,
+  snprintf_func(buf, TESTBUFSIZE, "%s -a -v -dq -R -s%s %s %s", program_name,
                 TEST_SOURCE_FILE, TEST_DELTA_FILE, TEST_RECON_FILE);
   if ((ret = do_cmd(stream, buf))) {
     return ret;
@@ -2242,7 +2242,7 @@ static int test_source_decompression(xd3_stream *stream, int ignore) {
 
   /* Decode the delta file with recompression, should get a compressed file
    * out.  But we can't compare compressed files directly. */
-  snprintf_func(buf, TESTBUFSIZE, "%s -v -dqf -s%s %s %s", program_name,
+  snprintf_func(buf, TESTBUFSIZE, "%s -a -v -dqf -s%s %s %s", program_name,
                 TEST_SOURCE_FILE, TEST_DELTA_FILE, TEST_RECON_FILE);
   if ((ret = do_cmd(stream, buf))) {
     return ret;
@@ -2257,7 +2257,7 @@ static int test_source_decompression(xd3_stream *stream, int ignore) {
   }
 
   /* Encode with decompression disabled */
-  snprintf_func(buf, TESTBUFSIZE, "%s -e -D -vfq -s%s %s %s", program_name,
+  snprintf_func(buf, TESTBUFSIZE, "%s -a -e -D -vfq -s%s %s %s", program_name,
                 TEST_SOURCE_FILE, TEST_TARGET_FILE, TEST_DELTA_FILE);
   if ((ret = do_cmd(stream, buf))) {
     return ret;
@@ -2265,7 +2265,7 @@ static int test_source_decompression(xd3_stream *stream, int ignore) {
 
   /* Decode the delta file with decompression disabled, should get the
    * identical compressed file out. */
-  snprintf_func(buf, TESTBUFSIZE, "%s -d -D -vfq -s%s %s %s", program_name,
+  snprintf_func(buf, TESTBUFSIZE, "%s -a -d -D -vfq -s%s %s %s", program_name,
                 TEST_SOURCE_FILE, TEST_DELTA_FILE, TEST_RECON_FILE);
   if ((ret = do_cmd(stream, buf))) {
     return ret;
@@ -2494,10 +2494,296 @@ static int test_appheader(xd3_stream *stream, int ignore) {
   return 0;
 }
 
+#if XD3_ARMOR
+/* BLAKE3 known-answer test against the official test vectors (default 32-byte
+ * output).  The input is the repeating byte sequence 0,1,...,250,0,1,...  This
+ * pins the digest values independently of xdelta3's own encode/decode. */
+static int test_armor_blake3_kat(xd3_stream *stream, int ignore) {
+  static const struct {
+    usize_t len;
+    const char *hex;
+  } kats[] = {
+      {0, "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262"},
+      {1, "2d3adedff11b61f14c886e35afa036736dcd87a74d27b5c1510225d0f592e213"},
+      {1024,
+       "42214739f095a406f3fc83deb889744ac00df831c10daa55189b5d121c855af7"},
+      {2048,
+       "e776b6028c7cd22a4d0ba182a8bf62205d2ef576467e838ed6f2529b85fba24a"},
+      {3072,
+       "b98cb0ff3623be03326b373de6b9095218513e64f1ee2edd2525c7ad1e5cffd2"},
+  };
+  const usize_t inlen = 3072;
+  uint8_t *inbuf;
+  usize_t i;
+  usize_t k;
+
+  if ((inbuf = (uint8_t *)main_malloc(inlen)) == NULL) {
+    return ENOMEM;
+  }
+  for (i = 0; i < inlen; i += 1) {
+    inbuf[i] = (uint8_t)(i % 251);
+  }
+
+  for (k = 0; k < SIZEOF_ARRAY(kats); k += 1) {
+    blake3_hasher h;
+    uint8_t digest[BLAKE3_OUT_LEN];
+    char got[XD3_BLAKE3_HEXBUF];
+
+    blake3_hasher_init(&h);
+    blake3_hasher_update(&h, inbuf, kats[k].len);
+    blake3_hasher_finalize(&h, digest, sizeof(digest));
+    main_armor_hex(digest, got);
+
+    if (strcmp(got, kats[k].hex) != 0) {
+      XPR(NT "BLAKE3 KAT mismatch at len %u:\n  expected %s\n  actual   %s\n",
+          (unsigned)kats[k].len, kats[k].hex, got);
+      stream->msg = "BLAKE3 known-answer test failed";
+      main_free(inbuf);
+      return XD3_INTERNAL;
+    }
+  }
+
+  main_free(inbuf);
+  return 0;
+}
+
+/* Tests armor mode (BLAKE3 whole-file verification): armored round-trip,
+ * fast failure on a wrong source, the -a opt-out / legacy header, and
+ * armored merge-chain verification including a broken chain. */
+static int test_armor(xd3_stream *stream, int ignore) {
+  int ret;
+  char buf[TESTBUFSIZE];
+  char d1[TESTFILESIZE];
+  char d2[TESTFILESIZE];
+  char v3[TESTFILESIZE];
+  char merged[TESTFILESIZE];
+  char wrong[TESTFILESIZE];
+  char warnf[TESTFILESIZE];
+  xoff_t ssize, tsize;
+
+  test_setup();
+  if ((ret = test_make_inputs(stream, &ssize, &tsize))) {
+    return ret;
+  }
+
+  /* Armored encode (default) of SOURCE -> TARGET. */
+  snprintf_func(buf, TESTBUFSIZE, "%s -q -f -e -s %s %s %s", program_name,
+                TEST_SOURCE_FILE, TEST_TARGET_FILE, TEST_DELTA_FILE);
+  if ((ret = do_cmd(stream, buf))) {
+    return ret;
+  }
+
+  /* The armored delta carries '#' digests in its app-header. */
+  snprintf_func(buf, TESTBUFSIZE,
+                "%s printhdr %s | grep -i 'application header' | grep -q '#'",
+                program_name, TEST_DELTA_FILE);
+  if ((ret = do_cmd(stream, buf))) {
+    stream->msg = "armor: expected digest in app-header";
+    return ret;
+  }
+
+  /* Decode with the correct source verifies and round-trips. */
+  snprintf_func(buf, TESTBUFSIZE, "%s -q -f -d -s %s %s %s", program_name,
+                TEST_SOURCE_FILE, TEST_DELTA_FILE, TEST_RECON_FILE);
+  if ((ret = do_cmd(stream, buf))) {
+    return ret;
+  }
+  if ((ret = test_compare_files(TEST_TARGET_FILE, TEST_RECON_FILE))) {
+    return ret;
+  }
+
+  /* Decode with an unrelated source must fail the armor pre-check (exit 1). */
+  snprintf_func(wrong, sizeof(wrong), "%s.wrong", TEST_DELTA_FILE);
+  snprintf_func(buf, TESTBUFSIZE, "cat %s %s > %s", TEST_SOURCE_FILE,
+                TEST_TARGET_FILE, wrong);
+  if ((ret = do_cmd(stream, buf))) {
+    return ret;
+  }
+  snprintf_func(buf, TESTBUFSIZE, "%s -q -f -d -s %s %s %s", program_name,
+                wrong, TEST_DELTA_FILE, TEST_RECON_FILE);
+  if ((ret = do_fail(stream, buf))) {
+    return ret;
+  }
+
+  /* Decode with the already-patched source (the target itself) reports
+   * "up to date" with the distinct exit code, not a generic failure. */
+  snprintf_func(buf, TESTBUFSIZE, "%s -q -f -d -s %s %s %s", program_name,
+                TEST_TARGET_FILE, TEST_DELTA_FILE, TEST_RECON_FILE);
+  {
+    int st = system(buf);
+    if (!WIFEXITED(st) || WEXITSTATUS(st) != EXIT_ARMOR_UP_TO_DATE) {
+      stream->msg = "armor: expected up-to-date exit code";
+      return XD3_INTERNAL;
+    }
+  }
+
+  /* A streaming (non-seekable) source cannot be verified: armor warns but the
+   * apply still succeeds.  Capture stderr and assert the warning is present. */
+  snprintf_func(warnf, sizeof(warnf), "%s.warn", TEST_DELTA_FILE);
+  snprintf_func(buf, TESTBUFSIZE, "cat %s | %s -f -d -s /dev/stdin %s %s 2>%s",
+                TEST_SOURCE_FILE, program_name, TEST_DELTA_FILE,
+                TEST_RECON_FILE, warnf);
+  if ((ret = do_cmd(stream, buf))) {
+    return ret;
+  }
+  if ((ret = test_compare_files(TEST_TARGET_FILE, TEST_RECON_FILE))) {
+    return ret;
+  }
+  snprintf_func(buf, TESTBUFSIZE, "grep -q 'source is not seekable' %s", warnf);
+  if ((ret = do_cmd(stream, buf))) {
+    stream->msg = "armor: expected streaming-source warning";
+    return ret;
+  }
+  test_unlink(warnf);
+  test_unlink(wrong);
+
+  /* -a decode skips armor; with the correct source it still round-trips. */
+  snprintf_func(buf, TESTBUFSIZE, "%s -q -f -a -d -s %s %s %s", program_name,
+                TEST_SOURCE_FILE, TEST_DELTA_FILE, TEST_RECON_FILE);
+  if ((ret = do_cmd(stream, buf))) {
+    return ret;
+  }
+  if ((ret = test_compare_files(TEST_TARGET_FILE, TEST_RECON_FILE))) {
+    return ret;
+  }
+
+  /* -a encode produces a legacy app-header with no digest. */
+  snprintf_func(buf, TESTBUFSIZE, "%s -q -f -a -e -s %s %s %s", program_name,
+                TEST_SOURCE_FILE, TEST_TARGET_FILE, TEST_DELTA_FILE);
+  if ((ret = do_cmd(stream, buf))) {
+    return ret;
+  }
+  snprintf_func(buf, TESTBUFSIZE,
+                "%s printhdr %s | grep -i 'application header' | grep -q '#'",
+                program_name, TEST_DELTA_FILE);
+  if ((ret = do_fail(stream, buf))) { /* grep finds no '#' -> exit 1 */
+    return ret;
+  }
+
+  /* Armored merge chain: SOURCE(v1) -> TARGET(v2) -> v3. */
+  snprintf_func(d1, sizeof(d1), "%s.d1", TEST_DELTA_FILE);
+  snprintf_func(d2, sizeof(d2), "%s.d2", TEST_DELTA_FILE);
+  snprintf_func(v3, sizeof(v3), "%s.v3", TEST_DELTA_FILE);
+  snprintf_func(merged, sizeof(merged), "%s.merged", TEST_DELTA_FILE);
+
+  snprintf_func(buf, TESTBUFSIZE, "cp %s %s && echo armor-extra-data >> %s",
+                TEST_TARGET_FILE, v3, v3);
+  if ((ret = do_cmd(stream, buf))) {
+    return ret;
+  }
+  snprintf_func(buf, TESTBUFSIZE, "%s -q -f -e -s %s %s %s", program_name,
+                TEST_SOURCE_FILE, TEST_TARGET_FILE, d1);
+  if ((ret = do_cmd(stream, buf))) {
+    return ret;
+  }
+  snprintf_func(buf, TESTBUFSIZE, "%s -q -f -e -s %s %s %s", program_name,
+                TEST_TARGET_FILE, v3, d2);
+  if ((ret = do_cmd(stream, buf))) {
+    return ret;
+  }
+  snprintf_func(buf, TESTBUFSIZE, "%s -f merge -m %s %s %s", program_name, d1,
+                d2, merged);
+  if ((ret = do_cmd(stream, buf))) {
+    return ret;
+  }
+  snprintf_func(buf, TESTBUFSIZE, "%s -q -f -d -s %s %s %s", program_name,
+                TEST_SOURCE_FILE, merged, TEST_RECON_FILE);
+  if ((ret = do_cmd(stream, buf))) {
+    return ret;
+  }
+  if ((ret = test_compare_files(v3, TEST_RECON_FILE))) {
+    return ret;
+  }
+
+  /* A broken chain (replace d2 with v3 -> v1) must be refused. */
+  snprintf_func(buf, TESTBUFSIZE, "%s -q -f -e -s %s %s %s", program_name, v3,
+                TEST_SOURCE_FILE, d2);
+  if ((ret = do_cmd(stream, buf))) {
+    return ret;
+  }
+  snprintf_func(buf, TESTBUFSIZE, "%s -f merge -m %s %s %s", program_name, d1,
+                d2, merged);
+  if ((ret = do_fail(stream, buf))) {
+    return ret;
+  }
+
+  test_unlink(d1);
+  test_unlink(d2);
+  test_unlink(v3);
+  test_unlink(merged);
+
+#if EXTERNAL_COMPRESSION
+  /* Armor verifies the logical (decompressed) content, so it works across
+   * external compression: encode/decode gzip'd inputs and round-trip. */
+  if (main_get_compressor("G") != NULL) {
+    char sgz[TESTFILESIZE];
+    char tgz[TESTFILESIZE];
+    snprintf_func(sgz, sizeof(sgz), "%s.sgz", TEST_DELTA_FILE);
+    snprintf_func(tgz, sizeof(tgz), "%s.tgz", TEST_DELTA_FILE);
+
+    snprintf_func(buf, TESTBUFSIZE, "gzip -1 < %s > %s && gzip -9 < %s > %s",
+                  TEST_SOURCE_FILE, sgz, TEST_TARGET_FILE, tgz);
+    if ((ret = do_cmd(stream, buf))) {
+      return ret;
+    }
+    /* Armored encode auto-decompresses both inputs. */
+    snprintf_func(buf, TESTBUFSIZE, "%s -q -f -e -s %s %s %s", program_name,
+                  sgz, tgz, TEST_DELTA_FILE);
+    if ((ret = do_cmd(stream, buf))) {
+      return ret;
+    }
+    /* Decode with -R (no recompression) yields the logical target content,
+     * which armor also verifies on the fly. */
+    snprintf_func(buf, TESTBUFSIZE, "%s -q -f -R -d -s %s %s %s", program_name,
+                  sgz, TEST_DELTA_FILE, TEST_RECON_FILE);
+    if ((ret = do_cmd(stream, buf))) {
+      return ret;
+    }
+    if ((ret = test_compare_files(TEST_TARGET_FILE, TEST_RECON_FILE))) {
+      return ret;
+    }
+    /* Applying with the already-patched (target) gzip source reports
+     * up-to-date -- the up-to-date detection works across external
+     * compression too. */
+    snprintf_func(buf, TESTBUFSIZE, "%s -q -f -R -d -s %s %s %s", program_name,
+                  tgz, TEST_DELTA_FILE, TEST_RECON_FILE);
+    {
+      int st = system(buf);
+      if (!WIFEXITED(st) || WEXITSTATUS(st) != EXIT_ARMOR_UP_TO_DATE) {
+        stream->msg = "armor: expected up-to-date exit code (gzip)";
+        return XD3_INTERNAL;
+      }
+    }
+
+    test_unlink(sgz);
+    test_unlink(tgz);
+  }
+#endif
+
+  /* Armored encode requires seekable inputs: a streaming (non-seekable) target
+   * or source is rejected.  Both forms feed the streaming input via a pipe (a
+   * "< file" redirect would still be a seekable regular file). */
+  snprintf_func(buf, TESTBUFSIZE, "cat %s | %s -f -e -s %s > %s",
+                TEST_TARGET_FILE, program_name, TEST_SOURCE_FILE,
+                TEST_DELTA_FILE);
+  if ((ret = do_fail(stream, buf))) {
+    return ret;
+  }
+  snprintf_func(buf, TESTBUFSIZE, "cat %s | %s -f -e -s /dev/stdin %s %s",
+                TEST_SOURCE_FILE, program_name, TEST_TARGET_FILE,
+                TEST_DELTA_FILE);
+  if ((ret = do_fail(stream, buf))) {
+    return ret;
+  }
+
+  test_cleanup();
+  return 0;
+}
+#endif /* XD3_ARMOR */
+
 /***********************************************************************
  Source identical optimization
  ***********************************************************************/
-
 /* Computing a delta should be fastest when the two inputs are
  * identical, this checks it.  The library is called to compute a
  * delta between a 10000 byte file, 1000 byte winsize, 500 byte source
@@ -2990,12 +3276,19 @@ int xd3_selftest(void) {
   IF_FGK(DO_TEST(decompress_single_bit_error, XD3_SEC_FGK, 3));
   IF_DJW(DO_TEST(decompress_single_bit_error, XD3_SEC_DJW, 8));
 
+#if XD3_ARMOR
+  DO_TEST(armor_blake3_kat, 0, 0);
+#endif
+
 #if SHELL_TESTS
   DO_TEST(force_behavior, 0, 0);
   DO_TEST(stdout_behavior, 0, 0);
   DO_TEST(no_output, 0, 0);
   DO_TEST(appheader, 0, 0);
   DO_TEST(command_line_arguments, 0, 0);
+#if XD3_ARMOR
+  DO_TEST(armor, 0, 0);
+#endif
 
 #if EXTERNAL_COMPRESSION
   DO_TEST(source_decompression, 0, 0);

--- a/xdelta3/xdelta3.1
+++ b/xdelta3/xdelta3.1
@@ -107,6 +107,30 @@ disable external recompression (decode)
 .BI \-n
 disable checksum (encode/decode)
 .TP
+.BI \-a
+disable armor.
+Armor mode (whole-file BLAKE3 verification) is on by default. When enabled,
+.B xdelta3
+embeds BLAKE3 digests of the source and target into the application header
+using the
+.I name#blake3
+syntax. On encode this requires a seekable source and target; on decode the
+source is verified before applying and the reconstructed target is verified
+afterward. If the source is a stream (not seekable) it cannot be verified, so
+.B xdelta3
+prints a warning and proceeds. If the supplied source already matches the
+delta's target digest -- i.e. the patch is already applied -- decode reports
+"already up to date" and exits with status 2.
+.B \-a
+disables this and restores the legacy application-header format and the
+non-seekable streaming behavior. The
+.B merge
+command verifies an armored chain of deltas when every input is armored.
+Armor verifies the logical (decompressed) content that
+.B xdelta3
+processes, so it composes correctly with external input decompression and
+output recompression.
+.TP
 .BI \-C 
 soft config (encode, undocumented)
 .TP
@@ -118,6 +142,18 @@ disable output (check/compute only)
 .TP
 .BI \-T
 use alternate code table (test)
+
+.SH "EXIT STATUS"
+.TP
+.B 0
+success.
+.TP
+.B 2
+the decoded armored delta's source already matches its target digest; the
+patch is already applied and nothing was done.
+.TP
+.B 1
+any other error.
 
 .SH NOTES
 The 


### PR DESCRIPTION
Armor mode (on by default; -a disables it) embeds BLAKE3 digests of the source and target into the VCDIFF application header using a "name#blake3" syntax, so the format stays byte-compatible with legacy xdelta3.

- Encode hashes the source and target up front and embeds both digests; requires seekable inputs.
- Decode verifies the source before applying and the reconstructed target on the fly afterward, failing fast with a clear message on mismatch.
- Digests cover the logical (decompressed) content xdelta3 processes, not the raw on-disk bytes, so armor composes correctly with external input decompression and output recompression.
- merge verifies an armored chain of deltas (delta[i].target == delta[i+1].source) and re-arms the merged output; broken chains are refused.
- When the supplied source already matches the target digest, decode reports "already up to date" and exits with status 2.
- A streaming (non-seekable) source cannot be verified, so decode warns and proceeds.

BLAKE3 is fetched at configure time from its official repository, pinned to a release tag (-DXD3_BLAKE3_TAG); build with -DXD3_ARMOR=OFF to drop the dependency and behave as if -a were always given.

Tests: armored round-trip, wrong-source fast failure, up-to-date exit code, streaming-source warning, -a opt-out/legacy header, armored merge chain and broken-chain refusal, external-compression round-trip, encode non-seekable rejection, and a BLAKE3 known-answer test against the official vectors. The Go harness and external-compression self-tests pass -a for their piped/ non-seekable invocations.