### PR TITLE
Clamp the source window size

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,34 @@ jobs:
       - name: Test
         run: ctest --test-dir build --output-on-failure
 
+  cmake-small-usize:
+    name: ${{ matrix.os }} / 32-bit usize_t
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
+    defaults:
+      run:
+        working-directory: xdelta3
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Configure (XD3_LARGESIZET=OFF)
+        run: >
+          cmake -B build
+          -DCMAKE_BUILD_TYPE=Release
+          -DXD3_LARGESIZET=OFF
+          -DXD3_LZMA_MODE=off
+          -DXD3_WERROR=ON
+          -DCMAKE_PREFIX_PATH="$(brew --prefix 2>/dev/null || echo /usr)"
+
+      - name: Build
+        run: cmake --build build --config Release -j
+
+      - name: Test
+        run: ctest --test-dir build --output-on-failure
+
   windows:
     name: windows-latest / lzma=${{ matrix.lzma }}
     runs-on: windows-latest

--- a/xdelta3/CMakeLists.txt
+++ b/xdelta3/CMakeLists.txt
@@ -22,6 +22,13 @@ set_property(CACHE XD3_LZMA_MODE PROPERTY STRINGS auto on off)
 
 option(XD3_WERROR "Treat compiler warnings as errors for the core targets" OFF)
 
+# Window size type width.  ON (default) selects a 64-bit usize_t; OFF selects
+# the historical/embedded 32-bit usize_t (XD3_USE_LARGESIZET=0) where absolute
+# 64-bit xoff_t offsets are narrowed into 32-bit window-relative usize_t
+# values.  The OFF build exercises those narrowing paths so the regression
+# suite covers the mixed-width configuration.
+option(XD3_LARGESIZET "Use a 64-bit window size type (usize_t)" ON)
+
 # Armor mode: whole-file BLAKE3 verification carried in the VCDIFF app-header.
 # When ON, the official BLAKE3 C library is fetched (pinned tag) and linked into
 # the xdelta3 command-line tool.  When OFF, armor is compiled out and the tool
@@ -133,7 +140,8 @@ endif()
 # Helper to apply shared settings to a target.
 function(xd3_configure_target target)
   target_include_directories(${target} PRIVATE ${XD3_INCLUDE_DIRS})
-  target_compile_definitions(${target} PRIVATE HAVE_CONFIG_H=1)
+  target_compile_definitions(${target} PRIVATE HAVE_CONFIG_H=1
+    XD3_USE_LARGESIZET=$<BOOL:${XD3_LARGESIZET}>)
   target_compile_options(${target} PRIVATE ${XD3_WFLAGS})
   set_target_properties(${target} PROPERTIES
     C_STANDARD 99 C_STANDARD_REQUIRED ON

--- a/xdelta3/xdelta3-blkcache.h
+++ b/xdelta3/xdelta3-blkcache.h
@@ -106,6 +106,18 @@ static int main_set_source(xd3_stream *stream, xd3_cmd cmd, main_file *sfile,
     sfile->size_known = (main_file_stat(sfile, &source_size) == 0);
   }
 
+  /* Clamp the source window to the known source size.  A large -B on a small
+   * source would otherwise reserve the full (rounded-up) window up front --
+   * e.g. an 8 GiB buffer for a 100 KB file -- wasting memory and risking
+   * out-of-memory failures.  Only shrink, never below XD3_MINSRCWINSZ, and only
+   * when the size is known; non-seekable sources keep the full window because
+   * they need it.  For an externally compressed source the known size is the
+   * compressed length, so the window is bounded by that length; this stays
+   * correct because the logical content is read through the block cache. */
+  if (sfile->size_known && source_size < option_srcwinsz) {
+    option_srcwinsz = xd3_max((xoff_t)XD3_MINSRCWINSZ, source_size);
+  }
+
   /* Note: The API requires a power-of-two blocksize and srcwinsz
    * (-B).  The logic here will use a single block if the entire file
    * is known to fit into srcwinsz. */

--- a/xdelta3/xdelta3-internal.h
+++ b/xdelta3/xdelta3-internal.h
@@ -360,6 +360,27 @@ static inline int xd3_emit_offset(xd3_stream *stream, xd3_output **output,
   (((size_t)(size) != 0) &&                                                    \
    ((size_t)(items) > ((size_t)SIZE_MAX) / (size_t)(size)))
 
+/* Checked narrowing of an absolute file offset (xoff_t) into a
+ * window-relative size or address (usize_t).  VCDIFF copy addresses are
+ * window-relative, so the encoder must reduce every xoff_t into a usize_t
+ * before emitting; the scheme is correct only while the value fits.  On the
+ * default build both types are 64-bit and the bound folds away, but on the
+ * XD3_USE_LARGESIZET=0 build usize_t is 32-bit and a bare cast silently
+ * truncates.  This converts that truncation into a clean error.  Stores the
+ * narrowed value through out on success and returns 0; returns
+ * XD3_INVALID_INPUT and leaves out unmodified when v exceeds USIZE_T_MAX.
+ * The SIZEOF guard avoids a tautological comparison when usize_t is already
+ * as wide as xoff_t. */
+static inline int xd3_to_usize(xoff_t v, usize_t *out) {
+#if SIZEOF_USIZE_T < SIZEOF_XOFF_T
+  if (v > (xoff_t)USIZE_T_MAX) {
+    return XD3_INVALID_INPUT;
+  }
+#endif
+  *out = (usize_t)v;
+  return 0;
+}
+
 int xd3_size_hashtable(xd3_stream *stream, usize_t slots, usize_t look,
                        xd3_hash_cfg *cfg);
 

--- a/xdelta3/xdelta3-test.h
+++ b/xdelta3/xdelta3-test.h
@@ -2651,8 +2651,8 @@ static int test_armor(xd3_stream *stream, int ignore) {
     static const char zeros[XD3_BLAKE3_HEXLEN + 1] =
         "0000000000000000000000000000000000000000000000000000000000000000";
 
-    if ((ret = main_armor_hash_file(TEST_SOURCE_FILE, "source", srchash,
-                                    NULL))) {
+    if ((ret =
+             main_armor_hash_file(TEST_SOURCE_FILE, "source", srchash, NULL))) {
       return ret;
     }
     snprintf_func(forged, sizeof(forged), "%s.forged", TEST_DELTA_FILE);

--- a/xdelta3/xdelta3-test.h
+++ b/xdelta3/xdelta3-test.h
@@ -2858,6 +2858,56 @@ static int test_armor(xd3_stream *stream, int ignore) {
 }
 #endif /* XD3_ARMOR */
 
+#if SHELL_TESTS
+/* Regression test for the source-window (-B) over-allocation behind #273/#251.
+ * A -B much larger than the source must not reserve the full window up front:
+ * encode with a 1 GiB -B over a small (~16 KiB) source, confirm the verbose
+ * source report shows a window clamped to the source size (well under a
+ * gigabyte) rather than the requested 1 GiB, and that the delta still applies
+ * correctly. */
+static int test_srcwin_clamp(xd3_stream *stream, int ignore) {
+  int ret;
+  char buf[TESTBUFSIZE];
+  char vlog[TESTFILESIZE];
+  xoff_t ssize, tsize;
+
+  test_setup();
+  if ((ret = test_make_inputs(stream, &ssize, &tsize))) {
+    return ret;
+  }
+
+  snprintf_func(vlog, sizeof(vlog), "%s.vlog", TEST_DELTA_FILE);
+  snprintf_func(buf, TESTBUFSIZE, "%s -e -v -f -B 1073741824 -s %s %s %s 2>%s",
+                program_name, TEST_SOURCE_FILE, TEST_TARGET_FILE,
+                TEST_DELTA_FILE, vlog);
+  if ((ret = do_cmd(stream, buf))) {
+    return ret;
+  }
+
+  /* The window must have been clamped: the verbose report must not claim a
+   * GiB-sized window (pre-fix it printed "window 1.00 GiB"). */
+  snprintf_func(buf, TESTBUFSIZE, "grep -i 'source size' %s | grep -q 'GiB'",
+                vlog);
+  if ((ret = do_fail(stream, buf))) {
+    stream->msg = "srcwin: window not clamped to source size";
+    return ret;
+  }
+
+  snprintf_func(buf, TESTBUFSIZE, "%s -d -f -s %s %s %s", program_name,
+                TEST_SOURCE_FILE, TEST_DELTA_FILE, TEST_RECON_FILE);
+  if ((ret = do_cmd(stream, buf))) {
+    return ret;
+  }
+  if ((ret = test_compare_files(TEST_TARGET_FILE, TEST_RECON_FILE))) {
+    return ret;
+  }
+
+  test_unlink(vlog);
+  test_cleanup();
+  return 0;
+}
+#endif /* SHELL_TESTS */
+
 /***********************************************************************
  Source identical optimization
  ***********************************************************************/
@@ -3363,6 +3413,7 @@ int xd3_selftest(void) {
   DO_TEST(no_output, 0, 0);
   DO_TEST(appheader, 0, 0);
   DO_TEST(command_line_arguments, 0, 0);
+  DO_TEST(srcwin_clamp, 0, 0);
 #if XD3_ARMOR
   DO_TEST(armor, 0, 0);
 #endif

--- a/xdelta3/xdelta3-test.h
+++ b/xdelta3/xdelta3-test.h
@@ -3348,6 +3348,65 @@ static int test_in_memory(xd3_stream *stream, int ignore) {
   return 0;
 }
 
+/* Regression for the usize_t / xoff_t mixed-width narrowing.  On the
+ * XD3_USE_LARGESIZET=0 build usize_t is 32-bit while xoff_t stays 64-bit, so
+ * window-relative quantities must be range-checked before they are narrowed.
+ * This verifies the checked-narrowing primitive and the library-level
+ * window-size caps reject out-of-range values with a clean error instead of
+ * silently truncating. */
+static int test_usize_narrowing(xd3_stream *stream, int ignore) {
+  usize_t out = 0;
+  xd3_stream s;
+  xd3_config c;
+  xd3_source src;
+  int ret;
+
+  /* In-range offsets narrow cleanly, including the maximum. */
+  if (xd3_to_usize(0, &out) != 0 || out != 0 ||
+      xd3_to_usize((xoff_t)USIZE_T_MAX, &out) != 0 || out != USIZE_T_MAX) {
+    stream->msg = "xd3_to_usize rejected an in-range value";
+    return XD3_INTERNAL;
+  }
+
+#if SIZEOF_USIZE_T < SIZEOF_XOFF_T
+  /* An offset beyond USIZE_T_MAX is rejected, not truncated. */
+  if (xd3_to_usize((xoff_t)USIZE_T_MAX + 1, &out) != XD3_INVALID_INPUT) {
+    stream->msg = "xd3_to_usize failed to reject an overflowing value";
+    return XD3_INTERNAL;
+  }
+#endif
+
+  /* xd3_config_stream rejects a winsize beyond the source-window cap. */
+  xd3_init_config(&c, 0);
+  c.winsize = (usize_t)(XD3_MAXSRCWINSZ + 1);
+  ret = xd3_config_stream(&s, &c);
+  if (ret != XD3_INVALID) {
+    if (ret == 0) {
+      xd3_free_stream(&s);
+    }
+    stream->msg = "config_stream accepted an oversized winsize";
+    return XD3_INTERNAL;
+  }
+
+  /* xd3_set_source rejects a max_winsize beyond the source-window cap. */
+  xd3_init_config(&c, 0);
+  if ((ret = xd3_config_stream(&s, &c)) != 0) {
+    return ret;
+  }
+  memset(&src, 0, sizeof(src));
+  src.blksize = XD3_ALLOCSIZE;
+  src.max_winsize = (xoff_t)XD3_MAXSRCWINSZ + 1;
+  src.name = "";
+  ret = xd3_set_source(&s, &src);
+  xd3_free_stream(&s);
+  if (ret != XD3_INVALID) {
+    stream->msg = "set_source accepted an oversized max_winsize";
+    return XD3_INTERNAL;
+  }
+
+  return 0;
+}
+
 /***********************************************************************
  TEST MAIN
  ***********************************************************************/
@@ -3381,6 +3440,7 @@ int xd3_selftest(void) {
   DO_TEST(encode_decode_uint32_t, 0, 0);
   DO_TEST(encode_decode_uint64_t, 0, 0);
   DO_TEST(usize_t_overflow, 0, 0);
+  DO_TEST(usize_narrowing, 0, 0);
   DO_TEST(alloc_overflow, 0, 0);
   DO_TEST(checksum_step, 0, 0);
   DO_TEST(forward_match, 0, 0);

--- a/xdelta3/xdelta3.c
+++ b/xdelta3/xdelta3.c
@@ -1564,6 +1564,15 @@ int xd3_config_stream(xd3_stream *stream, xd3_config *config) {
   stream->winsize = config->winsize ? config->winsize : XD3_DEFAULT_WINSIZE;
   stream->sprevsz = config->sprevsz ? config->sprevsz : XD3_DEFAULT_SPREVSZ;
 
+  /* Enforce the window-size cap in the library, not just the CLI arg
+   * parser.  Window-relative copy addresses are narrowed to usize_t, so a
+   * winsize beyond XD3_MAXSRCWINSZ could overflow on a 32-bit-usize_t build
+   * regardless of how the caller reached this point. */
+  if (stream->winsize > XD3_MAXSRCWINSZ) {
+    stream->msg = "winsize exceeds the maximum source window size";
+    return XD3_INVALID;
+  }
+
   if (config->iopt_size == 0) {
     stream->iopt_size = XD3_ALLOCSIZE / sizeof(xd3_rinst);
     stream->iopt_unlimited = 1;
@@ -1776,6 +1785,15 @@ int xd3_set_source(xd3_stream *stream, xd3_source *src) {
     IF_DEBUG1(DP(RINT "raising src_maxsize to %" W "u\n", src->blksize));
   }
   src->max_winsize = xd3_max(src->max_winsize, XD3_ALLOCSIZE);
+
+  /* Enforce the source-window cap in the library.  srclen and source-copy
+   * addresses are window-relative usize_t values bounded by max_winsize;
+   * a value beyond XD3_MAXSRCWINSZ could overflow on a 32-bit-usize_t
+   * build, so reject it here rather than trusting the CLI arg parser. */
+  if (src->max_winsize > XD3_MAXSRCWINSZ) {
+    stream->msg = "source max_winsize exceeds the maximum";
+    return XD3_INVALID;
+  }
   return 0;
 }
 
@@ -1927,18 +1945,27 @@ static int xd3_iopt_finish_encoding(xd3_stream *stream, xd3_rinst *inst) {
       if (inst->xtra) {
         XD3_ASSERT(inst->addr >= src->srcbase);
         XD3_ASSERT(inst->addr + inst->size <= src->srcbase + src->srclen);
-        addr = inst->addr - src->srcbase;
+        if ((ret = xd3_to_usize(inst->addr - src->srcbase, &addr))) {
+          stream->msg = "source copy address exceeds window size";
+          return ret;
+        }
         stream->n_scpy += 1;
         stream->l_scpy += inst->size;
       } else {
         /* with source window: target copy address is offset
          * by taroff. */
-        addr = stream->taroff + inst->addr;
+        if ((ret = xd3_to_usize((xoff_t)stream->taroff + inst->addr, &addr))) {
+          stream->msg = "target copy address exceeds window size";
+          return ret;
+        }
         stream->n_tcpy += 1;
         stream->l_tcpy += inst->size;
       }
     } else {
-      addr = inst->addr;
+      if ((ret = xd3_to_usize(inst->addr, &addr))) {
+        stream->msg = "copy address exceeds window size";
+        return ret;
+      }
       stream->n_tcpy += 1;
       stream->l_tcpy += inst->size;
     }


### PR DESCRIPTION
Avoid allocating the full -B size when the source file is seekable with known size smaller.