### PR TITLE
Add 3.2.0 release process with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,28 @@ jobs:
       - name: Test
         run: ctest --test-dir build --output-on-failure
 
+  cmake-static-lzma:
+    name: ${{ matrix.os }} / fetched static liblzma
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Configure (XD3_LZMA_FETCH=ON)
+        working-directory: xdelta3
+        run: cmake -B build -DCMAKE_BUILD_TYPE=Release -DXD3_LZMA_FETCH=ON
+
+      - name: Build
+        working-directory: xdelta3
+        run: cmake --build build --config Release -j
+
+      - name: Test
+        working-directory: xdelta3
+        run: ctest --test-dir build -C Release --output-on-failure
+
   windows:
     name: windows-latest / lzma=${{ matrix.lzma }}
     runs-on: windows-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,161 @@
+name: Release
+
+# Publishes a release when a v* tag is pushed (e.g. v3.2.0).  See RELEASING.md
+# for the full procedure.  The workflow verifies that the tag matches the
+# version baked into the sources, builds prebuilt binaries for Linux, macOS,
+# and Windows, assembles a source tarball, and creates the GitHub Release.
+on:
+  push:
+    tags: [ 'v*' ]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing tag to (re)build a release for, e.g. v3.2.0'
+        required: true
+
+permissions:
+  contents: write
+
+env:
+  TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+
+jobs:
+  verify:
+    name: Verify version matches tag
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.check.outputs.version }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+
+      - name: Check tag against source version
+        id: check
+        run: |
+          set -euo pipefail
+          tag="${TAG}"
+          version="${tag#v}"
+          cmake_version="$(sed -n 's/^[[:space:]]*VERSION[[:space:]]\([0-9][0-9.]*\).*/\1/p' xdelta3/CMakeLists.txt | head -n1)"
+          if [ "$version" != "$cmake_version" ]; then
+            echo "::error::Tag $tag implies version $version but xdelta3/CMakeLists.txt has $cmake_version"
+            exit 1
+          fi
+          if ! grep -q "Xdelta version ${version}," xdelta3/xdelta3-main.h; then
+            echo "::error::xdelta3/xdelta3-main.h main_version() does not mention version $version"
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Verified release version $version for tag $tag"
+
+  source-tarball:
+    name: Source tarball
+    needs: verify
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+
+      - name: Create source tarball
+        run: |
+          set -euo pipefail
+          version="${{ needs.verify.outputs.version }}"
+          name="xdelta3-${version}"
+          git archive --format=tar.gz --prefix="${name}/" -o "${name}.tar.gz" HEAD
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: source-tarball
+          path: xdelta3-*.tar.gz
+
+  binaries:
+    name: ${{ matrix.name }} binaries
+    needs: verify
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            name: linux-x86_64
+          - os: macos-latest
+            name: macos-arm64
+          - os: windows-latest
+            name: windows-x86_64
+    defaults:
+      run:
+        working-directory: xdelta3
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+
+      # Prebuilt binaries are dependency-free: liblzma (xz) is fetched and
+      # statically linked via XD3_LZMA_FETCH, and armor (BLAKE3) is statically
+      # linked, so the tools need no system libraries at runtime.
+      - name: Configure
+        run: cmake -B build -DCMAKE_BUILD_TYPE=Release -DXD3_LZMA_FETCH=ON -DXD3_BUILD_TESTS=OFF
+
+      - name: Build
+        run: cmake --build build --config Release -j
+
+      - name: Smoke test
+        if: runner.os != 'Windows'
+        run: ./build/xdelta3 test
+
+      - name: Package (Unix)
+        if: runner.os != 'Windows'
+        run: |
+          set -euo pipefail
+          version="${{ needs.verify.outputs.version }}"
+          dir="xdelta3-${version}-${{ matrix.name }}"
+          mkdir "$dir"
+          cp build/xdelta3 build/xdelta3decode "$dir"/
+          cp xdelta3.1 ../README.md "$dir"/
+          tar -czf "${dir}.tar.gz" "$dir"
+
+      - name: Package (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $version = "${{ needs.verify.outputs.version }}"
+          $dir = "xdelta3-$version-${{ matrix.name }}"
+          New-Item -ItemType Directory -Path $dir | Out-Null
+          Copy-Item build/Release/xdelta3.exe, build/Release/xdelta3decode.exe $dir/
+          Copy-Item ../README.md $dir/
+          Compress-Archive -Path $dir -DestinationPath "$dir.zip"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: binaries-${{ matrix.name }}
+          path: |
+            xdelta3/xdelta3-*.tar.gz
+            xdelta3/xdelta3-*.zip
+
+  release:
+    name: Publish GitHub Release
+    needs: [ verify, source-tarball, binaries ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          version="${{ needs.verify.outputs.version }}"
+          gh release create "${TAG}" \
+            --title "Xdelta ${version}" \
+            --generate-notes \
+            --verify-tag \
+            dist/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,7 @@
-# CMake build directory
+# CMake build directories
 build/
+build_*/
 
 # Compiled objects and editor backups
 *.o
 *~
-
-# Generated configuration header (in case of an in-source build)
-config.h

--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@
 Xdelta version 3 is a C library and command-line tool for delta
 compression using VCDIFF/RFC 3284 streams.
 
-The current release series is **3.2.x**, developed on the `main` branch.
-The 2016-era **3.0.x** and **3.1.x** series are legacy.
+The current release series is **3.2.x**.
 
 # Building
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 Xdelta version 3 is a C library and command-line tool for delta
 compression using VCDIFF/RFC 3284 streams.
 
+The current release series is **3.2.x**, developed on the `main` branch.
+The 2016-era **3.0.x** and **3.1.x** series are legacy.
+
 # Building
 
 The sources live in the [`xdelta3`](xdelta3) directory.  To build with
@@ -20,6 +23,17 @@ ctest --test-dir build
 See [`xdelta3/README.md`](xdelta3/README.md) for more detail, including
 liblzma options and the Go regression-test harness.
 
+# Releases
+
+Prebuilt binaries for Linux, macOS, and Windows, plus a source tarball, are
+attached to each [GitHub Release](https://github.com/jmacd/xdelta/releases).
+The binaries are self-contained: liblzma (xz) and BLAKE3 are statically
+linked, so they need no system libraries at runtime.  Releases are cut by
+pushing a `vMAJOR.MINOR.PATCH` tag, which drives the
+[release workflow](.github/workflows/release.yml).  See
+[`RELEASING.md`](RELEASING.md) for the full procedure and the release-branch
+conventions (`releaseMAJOR_MINOR_apl`).
+
 # License
 
 This repository contains branches of Xdelta 3.x that were
@@ -30,11 +44,16 @@ namely:
 - __release3_0_apl__ Change to APL based on 3.0.11 sources
 - __release3_1_apl__ Merges release3_0_apl with 3.1.0 sources
 
+The `main` branch and the 3.2.x series (`release3_2_apl`) continue under the
+same Apache 2.0 license.
+
 The original GPL licensed Xdelta lives at http://github.com/jmacd/xdelta-gpl.
 
 # Documentation
 
 See the [command-line usage](https://github.com/jmacd/xdelta/blob/wiki/CommandLineSyntax.md).  See [wiki directory](https://github.com/jmacd/xdelta/tree/wiki).
+The wiki content is being migrated to a GitHub Pages site; this section will
+be updated to point there once it is published.
 
 
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,125 @@
+# Releasing Xdelta
+
+This document describes how to cut a new Xdelta release.  Releases are
+infrequent, so the goal is a short, repeatable checklist that leans on
+GitHub Actions to do the heavy lifting.
+
+## Overview
+
+Releases are driven entirely by **annotated git tags** of the form
+`vMAJOR.MINOR.PATCH` (for example `v3.2.0`).  Pushing such a tag triggers the
+[`Release`](.github/workflows/release.yml) workflow, which:
+
+1. Verifies that the tag matches the version baked into the sources.
+2. Builds dependency-free prebuilt binaries for Linux, macOS, and Windows.
+3. Assembles a source tarball with `git archive`.
+4. Publishes a GitHub Release with auto-generated notes and all of the above
+   attached as assets.
+
+## Branch and tag conventions
+
+Xdelta keeps a long-lived **release branch per minor series**, named
+`releaseMAJOR_MINOR_apl` (the `_apl` suffix records that these sources are the
+Apache-licensed line).  Historically:
+
+- `release3_0_apl` — the 3.0.x series (tags `v3.0.9`, `v3.0.10`, `v3.0.11`).
+- `release3_1_apl` — the 3.1.x series (tag `v3.1.0`).
+
+New development happens on `main`.  When a minor series is ready to ship, it is
+branched off `main` into a new `releaseMAJOR_MINOR_apl` branch, and point
+releases for that series are tagged on that branch.  The 3.2.0 release
+introduces `release3_2_apl`.
+
+CI (`.github/workflows/ci.yml`) runs on `main` and on the active release
+branches, so add new release branches to its `push:` trigger list when you
+create them.
+
+## Versioning
+
+The version lives in two places that must stay in sync; the release workflow
+fails fast if the tag disagrees with either:
+
+- `xdelta3/CMakeLists.txt` — the `project(... VERSION x.y.z ...)` line.
+- `xdelta3/xdelta3-main.h` — the `Xdelta version x.y.z` string in
+  `main_version()`.
+
+## Cutting a new minor release (e.g. 3.2.0)
+
+1. **Make sure `main` is green.**  Wait for CI on `main` to pass.
+
+2. **Create the release branch** from `main`:
+
+   ```sh
+   git checkout main && git pull
+   git checkout -b release3_2_apl
+   ```
+
+3. **Set the version** to `3.2.0` in both files listed under
+   [Versioning](#versioning), then commit:
+
+   ```sh
+   git commit -am "Release 3.2.0"
+   ```
+
+4. **Add the branch to CI.**  In `.github/workflows/ci.yml`, add
+   `release3_2_apl` to the `on: push: branches:` list, and commit that too.
+
+5. **Push the branch** and let CI run:
+
+   ```sh
+   git push -u origin release3_2_apl
+   ```
+
+6. **Tag and push** once CI is green:
+
+   ```sh
+   git tag -a v3.2.0 -m "Xdelta 3.2.0"
+   git push origin v3.2.0
+   ```
+
+7. **Watch the release.**  The `Release` workflow runs on the tag and creates
+   the GitHub Release.  Review the auto-generated notes and edit them if
+   needed:
+
+   ```sh
+   gh run watch
+   gh release view v3.2.0 --web
+   ```
+
+## Cutting a point release (e.g. 3.2.1)
+
+Point releases stay on the existing series branch:
+
+```sh
+git checkout release3_2_apl && git pull
+# ... cherry-pick or commit fixes ...
+# bump the version to 3.2.1 in the two files above
+git commit -am "Release 3.2.1"
+git push
+# once CI is green:
+git tag -a v3.2.1 -m "Xdelta 3.2.1"
+git push origin v3.2.1
+```
+
+## Re-running a release build
+
+If the release job needs to be re-run for an existing tag (for example after a
+transient runner failure), trigger the workflow manually:
+
+```sh
+gh workflow run release.yml -f tag=v3.2.0
+```
+
+`gh release create` is not idempotent, so delete the partial release first if
+one was created:
+
+```sh
+gh release delete v3.2.0 --yes
+```
+
+## Documentation
+
+User-facing documentation historically lived on the `wiki` branch (for
+example `CommandLineSyntax.md`).  That content is being migrated to a GitHub
+Pages site; until that lands, the `wiki` branch remains the source of truth.
+Keep `README.md` pointing at the canonical documentation location as it moves.

--- a/xdelta3/CMakeLists.txt
+++ b/xdelta3/CMakeLists.txt
@@ -9,7 +9,7 @@
 cmake_minimum_required(VERSION 3.13)
 
 project(xdelta3
-  VERSION 3.1.1
+  VERSION 3.2.0
   DESCRIPTION "VCDIFF (RFC 3284) delta compression library and tool"
   HOMEPAGE_URL "https://github.com/jmacd/xdelta"
   LANGUAGES C CXX)
@@ -19,6 +19,15 @@ option(XD3_BUILD_TESTS "Build the regression-test executables" ON)
 set(XD3_LZMA_MODE "auto" CACHE STRING
   "liblzma secondary compression: auto, on, or off")
 set_property(CACHE XD3_LZMA_MODE PROPERTY STRINGS auto on off)
+
+# When ON, liblzma (xz) is fetched and built as a static library via
+# FetchContent (pinned to XD3_LZMA_TAG) and linked into xdelta3, instead of
+# using a system liblzma.  This yields a dependency-free binary with liblzma
+# secondary compression and is what the release workflow uses.  It overrides
+# XD3_LZMA_MODE and requires CMake >= 3.20 (the minimum xz's build needs).
+option(XD3_LZMA_FETCH "Fetch and statically link liblzma (xz) via FetchContent" OFF)
+set(XD3_LZMA_TAG "v5.8.3" CACHE STRING
+  "xz/liblzma release tag to fetch when XD3_LZMA_FETCH=ON")
 
 option(XD3_WERROR "Treat compiler warnings as errors for the core targets" OFF)
 
@@ -52,7 +61,36 @@ check_type_size("unsigned long long" SIZEOF_UNSIGNED_LONG_LONG)
 # liblzma (secondary compression).
 set(HAVE_LZMA_H OFF)
 set(XD3_LZMA_LIBRARIES "")
-if(NOT XD3_LZMA_MODE STREQUAL "off")
+if(XD3_LZMA_FETCH)
+  if(CMAKE_VERSION VERSION_LESS 3.20)
+    message(FATAL_ERROR
+      "XD3_LZMA_FETCH=ON requires CMake >= 3.20 (xz's build); "
+      "use a system liblzma via XD3_LZMA_MODE instead.")
+  endif()
+  # Build a minimal static liblzma: no CLI tools, docs, or translations.
+  set(BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)
+  set(XZ_NLS OFF CACHE BOOL "" FORCE)
+  set(XZ_DOC OFF CACHE BOOL "" FORCE)
+  set(XZ_TOOL_XZ OFF CACHE BOOL "" FORCE)
+  set(XZ_TOOL_XZDEC OFF CACHE BOOL "" FORCE)
+  set(XZ_TOOL_LZMADEC OFF CACHE BOOL "" FORCE)
+  set(XZ_TOOL_LZMAINFO OFF CACHE BOOL "" FORCE)
+  set(XZ_TOOL_SCRIPTS OFF CACHE BOOL "" FORCE)
+  set(XZ_TOOL_SYMLINKS OFF CACHE BOOL "" FORCE)
+  include(FetchContent)
+  FetchContent_Declare(liblzma
+    GIT_REPOSITORY https://github.com/tukaani-project/xz.git
+    GIT_TAG ${XD3_LZMA_TAG}
+    GIT_SHALLOW TRUE)
+  FetchContent_MakeAvailable(liblzma)
+  # xz marks the public api/ directory PRIVATE on its in-tree target, so expose
+  # it (and the LZMA_API_STATIC define it sets) to consumers ourselves.
+  target_include_directories(liblzma INTERFACE
+    "$<BUILD_INTERFACE:${liblzma_SOURCE_DIR}/src/liblzma/api>")
+  set(HAVE_LZMA_H ON)
+  set(XD3_LZMA_LIBRARIES liblzma)
+  message(STATUS "xdelta3: liblzma fetched and statically linked (xz ${XD3_LZMA_TAG})")
+elseif(NOT XD3_LZMA_MODE STREQUAL "off")
   find_package(LibLZMA)
   if(LibLZMA_FOUND)
     set(HAVE_LZMA_H ON)

--- a/xdelta3/README.md
+++ b/xdelta3/README.md
@@ -40,6 +40,15 @@ liblzma is autodetected.  Force it on or off with `-DXD3_LZMA_MODE=on`
 or `-DXD3_LZMA_MODE=off`.  On Homebrew systems, point CMake at the
 prefix with `-DCMAKE_PREFIX_PATH="$(brew --prefix)"`.
 
+Alternatively, build a self-contained tool by fetching and statically
+linking liblzma (xz) instead of using a system copy:
+
+  cmake -B build -DCMAKE_BUILD_TYPE=Release -DXD3_LZMA_FETCH=ON
+
+`-DXD3_LZMA_FETCH=ON` overrides `XD3_LZMA_MODE`, requires CMake >= 3.20,
+and pins the xz release with `-DXD3_LZMA_TAG=...`.  This is how the
+release binaries are built, so they need no liblzma at runtime.
+
 Armor mode (whole-file verification)
 ------------------------------------
 

--- a/xdelta3/xdelta3-main.h
+++ b/xdelta3/xdelta3-main.h
@@ -389,7 +389,7 @@ void xprintf(const char *fmt, ...) {
 static int main_version(void) {
   /* $Format: "  XPR(NTR \"Xdelta version $Xdelta3Version$, Copyright (C)
    * Joshua MacDonald\\n\");" $ */
-  XPR(NTR "Xdelta version 3.1.1, Copyright (C) Joshua MacDonald\n");
+  XPR(NTR "Xdelta version 3.2.0, Copyright (C) Joshua MacDonald\n");
   XPR(NTR "Xdelta comes with ABSOLUTELY NO WARRANTY.\n");
   XPR(NTR "Licensed under the Apache License, Version 2.0\n");
   XPR(NTR "See \"LICENSE\" for details.\n");


### PR DESCRIPTION
Introduce a tag-driven release workflow and document the procedure so that infrequent releases are easy and repeatable.

- Add .github/workflows/release.yml: on a v* tag push (or manual dispatch) it verifies the tag matches the in-source version, builds dependency-free prebuilt binaries for Linux/macOS/Windows, assembles a source tarball, and publishes a GitHub Release with generated notes.
- Add RELEASING.md documenting the releaseMAJOR_MINOR_apl branch convention, the two version locations, and the minor/point release and re-run procedures.
- Make release binaries self-contained: add the XD3_LZMA_FETCH CMake option that FetchContent-builds a static liblzma (xz, pinned via XD3_LZMA_TAG), so binaries carry lzma support with no runtime dependency. Add a cmake-static-lzma CI job to guard the path.
- Bump the version to 3.2.0 (CMakeLists.txt and xdelta3-main.h) so main is ready to branch into release3_2_apl.
- Update README.md / xdelta3/README.md: current 3.2.x series, Releases section, and XD3_LZMA_FETCH usage.