### PR TITLE
Add MkDocs documentation site under site/

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -1,0 +1,63 @@
+name: Site
+
+# Builds the MkDocs documentation site in site/ and deploys it to GitHub Pages.
+# Deploys on pushes to main that touch the site; builds (without deploying) on
+# pull requests so broken docs are caught in review.
+on:
+  push:
+    branches: [ main ]
+    paths: [ 'site/**', '.github/workflows/site.yml' ]
+  pull_request:
+    paths: [ 'site/**', '.github/workflows/site.yml' ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment; cancel in-progress runs for the same ref.
+concurrency:
+  group: pages-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build site
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: site
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+          cache: pip
+          cache-dependency-path: site/requirements.txt
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Build (strict)
+        run: mkdocs build --strict
+
+      - name: Upload Pages artifact
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site/_site
+
+  deploy:
+    name: Deploy to GitHub Pages
+    if: github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ build_*/
 # Compiled objects and editor backups
 *.o
 *~
+
+# MkDocs build output (site/mkdocs.yml sets site_dir: _site)
+site/_site/
+

--- a/README.md
+++ b/README.md
@@ -50,9 +50,15 @@ The original GPL licensed Xdelta lives at http://github.com/jmacd/xdelta-gpl.
 
 # Documentation
 
-See the [command-line usage](https://github.com/jmacd/xdelta/blob/wiki/CommandLineSyntax.md).  See [wiki directory](https://github.com/jmacd/xdelta/tree/wiki).
-The wiki content is being migrated to a GitHub Pages site; this section will
-be updated to point there once it is published.
+Full documentation is published at **<https://jmacd.github.io/xdelta/>**,
+including the [command-line syntax](https://jmacd.github.io/xdelta/commandline/),
+[armor mode](https://jmacd.github.io/xdelta/armor/), and the
+[programming guide](https://jmacd.github.io/xdelta/programming-guide/).
+
+The site sources live in [`site/`](site) (MkDocs + Material) and are built and
+deployed by [`.github/workflows/site.yml`](.github/workflows/site.yml).  These
+pages were migrated and updated from the project's legacy
+[`wiki` branch](https://github.com/jmacd/xdelta/tree/wiki).
 
 
 

--- a/site/README.md
+++ b/site/README.md
@@ -1,0 +1,25 @@
+# Xdelta documentation site
+
+This directory contains the [MkDocs](https://www.mkdocs.org/) +
+[Material](https://squidfunk.github.io/mkdocs-material/) source for the Xdelta
+documentation site published at <https://jmacd.github.io/xdelta/>.
+
+The pages here were migrated from the project's old `wiki` branch and updated
+for the current 3.2.x sources (armor mode, liblzma, `merge`/`recode`, and the
+Apache 2.0 license).
+
+## Build and preview locally
+
+```sh
+cd site
+python -m venv .venv && . .venv/bin/activate   # optional
+pip install -r requirements.txt
+mkdocs serve        # live preview at http://127.0.0.1:8000/
+mkdocs build        # static output in site/_site/
+```
+
+## Deployment
+
+The site is built and deployed to GitHub Pages by
+[`.github/workflows/site.yml`](../.github/workflows/site.yml) on every push to
+`main` that touches `site/`.

--- a/site/docs/armor.md
+++ b/site/docs/armor.md
@@ -1,0 +1,68 @@
+# Armor mode
+
+**Armor mode** embeds [BLAKE3](https://github.com/BLAKE3-team/BLAKE3) digests of
+the source and target files in the VCDIFF application header and verifies them
+when applying a delta. It turns the classic late, ambiguous
+[target-window checksum mismatch](checksum-mismatch.md) into an immediate, clear
+error when the wrong source is supplied.
+
+Armor is **on by default**. Pass `-a` to disable it.
+
+## What it does
+
+When encoding, xdelta3 reads the source and target in full to compute their
+BLAKE3 digests and records them in the application header using a
+`name#blake3hex` syntax. When decoding:
+
+- The **source is verified up front**, before applying the delta. A wrong
+  source fails fast with a clear message instead of a late window-checksum
+  error.
+- The reconstructed **target is verified afterward**.
+- If the supplied source already matches the delta's *target* digest — i.e. the
+  patch is already applied — decode reports "already up to date" and exits with
+  status `2`.
+
+```sh
+# Encode (armor on by default); both files must be seekable regular files.
+xdelta3 -e -s old_file new_file delta_file
+
+# Decode verifies old_file before applying and new_file afterward.
+xdelta3 -d -s old_file delta_file decoded_new_file
+```
+
+## Requirements and behavior
+
+- **Seekable inputs.** Encoding needs to read both source and target twice, so
+  both must be seekable (regular) files. If a source is a stream (not seekable),
+  the decoder cannot verify it up front, so it prints a warning and proceeds.
+- **Logical content.** The digests cover the logical (decompressed) content
+  xdelta3 processes, not the raw on-disk bytes, so armor composes correctly with
+  [external compression](external-compression.md) of inputs and recompression
+  of output.
+- **`merge`.** Merging an armored chain of deltas verifies the chain when every
+  input is armored, and the merged delta is re-armored.
+
+## Disabling armor (`-a`)
+
+Pass `-a` to disable armor. This restores the legacy application-header format
+and the non-seekable streaming behavior — useful for piped input or when you do
+not want the extra read pass.
+
+!!! warning "Interoperating with legacy xdelta3"
+    Legacy xdelta3 builds (and builds without armor) read the armored `name#hex`
+    application-header values as literal filenames. To apply an armored delta
+    with such a build, specify the source and output explicitly with `-s` and an
+    output filename.
+
+## Building without armor
+
+Armor is controlled at build time by the CMake option `XD3_ARMOR` (default
+`ON`), which fetches and statically links BLAKE3. Configure with
+`-DXD3_ARMOR=OFF` to compile armor out entirely; the resulting tool behaves as
+if `-a` were always given and has no BLAKE3 dependency.
+
+## See also
+
+- [Command-line syntax](commandline.md) — the `-a` option and exit codes.
+- ["Target window checksum mismatch" explained](checksum-mismatch.md) — the
+  error armor is designed to pre-empt.

--- a/site/docs/better-compression.md
+++ b/site/docs/better-compression.md
@@ -1,0 +1,55 @@
+# Better compression (secondary compression)
+
+[VCDIFF](https://www.rfc-editor.org/rfc/rfc3284.txt) specifies a byte-code data
+format that does not use variable-bit-length codes. A byte-code-only format that
+is good on its own is desirable for many reasons, but a variable-bit-length
+encoding is naturally more efficient than a fixed-length code. VCDIFF also
+includes options for encoding and decoding with alternate byte-code tables.
+
+## Compression levels
+
+The `-1` … `-9` flags select alternate compression levels: `-1` is fastest and
+`-9` gives the best string-matching compression (at higher memory cost; see
+[Tuning the memory budget](tuning-memory.md)).
+
+## Secondary compression
+
+Even better compression can be achieved by applying a *secondary* compressor to
+the VCDIFF byte stream, selected with `-S`:
+
+- **`-S lzma`** — [LZMA](https://tukaani.org/xz/) (XZ Utils). Available when
+  xdelta3 was built with liblzma; usually the strongest option.
+- **`-S djw`** — the built-in DJW coder (described below).
+- **`-S fgk`** — the built-in adaptive Huffman (FGK) coder.
+- **`-S none`** — disable secondary compression.
+
+## The DJW coder
+
+DJW is named after [David Wheeler](https://en.wikipedia.org/wiki/David_Wheeler_(computer_scientist)).
+It is a semi-adaptive Huffman code in the spirit of the entropy-coding stage
+that follows the [Burrows–Wheeler transform](https://en.wikipedia.org/wiki/Burrows%E2%80%93Wheeler_transform)
+in [bzip2](https://en.wikipedia.org/wiki/Bzip2).
+
+The algorithm works with multiple Huffman-code tables over several iterations.
+The input is divided into fixed-length chunks, each chunk assigned to a Huffman
+table. On each iteration, chunks are reassigned to the table that gives the
+shortest encoding, then the tables are recomputed from the chunks assigned to
+them.
+
+The chunk encodings plus the chunk-to-table assignments are transformed by
+[move-to-front](https://en.wikipedia.org/wiki/Move-to-front_transform).
+Move-to-front works well (especially following Burrows–Wheeler), but it presents
+a problem for later Huffman coding: afterward there tend to be many `0`s, and a
+symbol with frequency greater than 50% cannot be encoded efficiently by Huffman
+coding, since even the shortest 1-bit code has redundancy. To address this, the
+`0` symbol is replaced by two symbols (call them `0_0` and `0_1`) that encode
+the run length of `0`s in binary.
+
+Xdelta3 also implements alternate code tables, but little work has been done on
+their optimization potential. See the `GENERIC_ENCODE_TABLES=1` build flag and
+related tests, which are not compiled by default.
+
+## See also
+
+[bsdiff](https://www.daemonology.net/bsdiff/) is another differential
+compression program, based on bzip2.

--- a/site/docs/checksum-mismatch.md
+++ b/site/docs/checksum-mismatch.md
@@ -1,0 +1,38 @@
+# "Target window checksum mismatch" explained
+
+This explains the `target window checksum mismatch: XD3_INVALID_INPUT` error.
+
+!!! tip "First, the short answer"
+    **This error almost always means you supplied the wrong source file.**
+    Verify the source with a strong checksum (for example `sha256sum`, or
+    BLAKE3) and confirm it matches the source used to create the delta.
+
+!!! note "Armor mode pre-empts this error"
+    Since the addition of [armor mode](armor.md) (on by default), an armored
+    delta carries whole-file BLAKE3 digests, so decoding **verifies the source
+    up front** and fails immediately with a clear message rather than a late
+    per-window checksum error. You will only see the window-checksum error
+    below for deltas produced (or applied) with armor disabled (`-a`), or for
+    non-seekable sources that cannot be verified up front. If you control the
+    encoding side, keeping armor enabled is the best way to avoid this error.
+
+## Why the error is reported so late (without armor)
+
+The xdelta3 command-line tool supports streaming both the source and the target
+inputs, so historically it could not verify a whole-file checksum before
+beginning. Because the VCDIFF format is window-oriented, integrity is checked at
+the granularity of a single window. As a result, a decoder using the wrong
+source may partially decode the input before a window checksum fails.
+
+Properly encoding and verifying a whole-file checksum as part of the patch would
+require two passes over the data during both encoding and decoding, and the
+VCDIFF format only allows metadata in the header — which is written before the
+entire source can be read. Armor mode solves this at the application-header
+level by recording BLAKE3 digests and reading the inputs in full; see
+[Armor mode](armor.md).
+
+## Other possible causes
+
+The target-window checksum is a catch-all. Besides the wrong source file (the
+only "normal" cause), an incorrect encoding (a bug), hardware failure, or an
+internal error could trigger it. Check the source file first.

--- a/site/docs/commandline.md
+++ b/site/docs/commandline.md
@@ -1,0 +1,137 @@
+# Command-line syntax
+
+The command-line syntax is like **gzip**, with the additional option
+`-s SOURCE`.
+
+As with gzip, `-d` means decompress and the default mode (`-e`) is to compress;
+`-c` writes to standard output and `-f` forces overwrite. Unlike gzip, xdelta3
+defaults to stdout instead of choosing a file extension automatically. Without
+`-s SOURCE`, xdelta3 behaves like gzip for stdin/stdout purposes.
+
+## Compress (encode) examples
+
+```sh
+xdelta3 -e -s SOURCE TARGET > OUT
+xdelta3 -e -s SOURCE TARGET OUT
+xdelta3 -e -s SOURCE < TARGET > OUT
+```
+
+## Decompress (decode) examples
+
+```sh
+xdelta3 -d -s SOURCE OUT > TARGET
+xdelta3 -d -s SOURCE OUT TARGET
+xdelta3 -d -s SOURCE < OUT > TARGET
+```
+
+## Usage summary
+
+The following reflects the built-in help (`xdelta3 -h`) for the current
+release. Some commands and options depend on build-time configuration.
+
+```
+usage: xdelta3 [command/options] [input [output]]
+make patch:
+
+  xdelta3 -e -s old_file new_file delta_file
+
+apply patch:
+
+  xdelta3 -d -s old_file delta_file decoded_new_file
+
+special command names:
+    config      prints xdelta3 configuration
+    decode      decompress the input
+    encode      compress the input
+    test        run the builtin tests
+special commands for VCDIFF inputs:
+    printdelta  print information about the entire delta
+    printhdr    print information about the first window
+    printhdrs   print information about all windows
+    recode      encode with new application/secondary settings
+    merge       merge VCDIFF inputs (see below)
+merge patches:
+
+  xdelta3 merge -m 1.vcdiff -m 2.vcdiff 3.vcdiff merged.vcdiff
+
+standard options:
+   -0 .. -9     compression level
+   -c           use stdout
+   -d           decompress
+   -e           compress
+   -f           force (overwrite, ignore trailing garbage)
+   -F           force the external-compression subprocess
+   -h           show help
+   -q           be quiet
+   -v           be verbose (max 2)
+   -V           show version
+memory options:
+   -B bytes     source window size
+   -W bytes     input window size
+   -P size      compression duplicates window
+   -I size      instruction buffer size (0 = unlimited)
+compression options:
+   -s source    source file to copy from (if any)
+   -S [lzma|djw|fgk] enable/disable secondary compression
+   -N           disable small string-matching compression
+   -D           disable external decompression (encode/decode)
+   -R           disable external recompression (decode)
+   -n           disable checksum (encode/decode)
+   -a           disable armor (whole-file BLAKE3 verification,
+                on by default; requires a seekable source)
+   -C           soft config (encode, undocumented)
+   -A [apphead] disable/provide application header (encode)
+   -J           disable output (check/compute only)
+   -m           arguments for "merge"
+the XDELTA environment variable may contain extra args:
+   XDELTA="-s source-x.y.tar.gz" \
+   tar --use-compress-program=xdelta3 \
+       -cf target-x.z.tar.gz.vcdiff target-x.y
+```
+
+## Notes on selected options
+
+### `-S` secondary compression
+
+`-S lzma` selects [LZMA](https://tukaani.org/xz/) secondary compression (only
+available when xdelta3 was built with liblzma); `-S djw` and `-S fgk` select the
+built-in coders; `-S none` disables it. See
+[Better compression](better-compression.md).
+
+### `-a` armor
+
+Armor mode embeds BLAKE3 digests of the source and target in the delta and
+verifies them, so applying a patch against the wrong source fails immediately
+with a clear message. It is **on by default** and requires a seekable
+(regular) source file. Pass `-a` to disable it and restore the legacy
+streaming behavior. See [Armor mode](armor.md).
+
+### `-A` application header
+
+The `-A` flag sets application-specific data in the VCDIFF header (view it with
+`xdelta3 printhdr`). By default the application header includes the source and
+input filenames plus descriptors used by
+[external compression](external-compression.md). Disable it with `-A=`.
+
+### `merge` and `recode`
+
+`recode` re-encodes an existing delta with new application/secondary settings.
+`merge` collapses a chain of deltas into one; given deltas `1→2` and `2→3` it
+produces a `1→3` delta:
+
+```sh
+xdelta3 merge -m 1.vcdiff -m 2.vcdiff 3.vcdiff merged.vcdiff
+```
+
+## Exit status
+
+| Code | Meaning |
+| ---- | ------- |
+| `0`  | success |
+| `1`  | generic failure (I/O error, wrong source, malformed input, …) |
+| `2`  | armored patch already applied: the supplied source already matches the delta's target digest ("already up to date") |
+
+## See also
+
+- [Tuning the memory budget](tuning-memory.md) for `-B`, `-W`, `-I`, `-P`.
+- ["Target window checksum mismatch" explained](checksum-mismatch.md).

--- a/site/docs/external-compression.md
+++ b/site/docs/external-compression.md
@@ -1,0 +1,50 @@
+# External compression
+
+To compute a delta between *externally-compressed* inputs (for example
+`xdelta3 -e -s source.gz target.gz`), xdelta3 recognizes several common
+compression programs and decompresses the data before reading it, including
+`gzip`, `bzip2`, and `compress`. When the decoder finishes, it re-applies the
+external compression to the output.
+
+!!! warning "Not available on Windows"
+    External compression is not supported on Windows. Decompress the inputs
+    manually before running xdelta3.
+
+## How it works
+
+Xdelta decompresses the inputs by piping them through the external compression
+program. Recognition of externally-compressed inputs can be disabled with `-D`.
+
+External compression has a well-known pitfall: xdelta3 does not know the
+original compression settings, so when re-applying the external compression it
+uses default settings, which may produce different compressed bytes and break
+checksum verification of the compressed data. External recompression of the
+output can be disabled with `-R`. If you know the settings needed to reproduce
+the exact output (for example `gzip -9`), set the corresponding environment
+variable to control the external command (for example `export GZIP=-9`).
+
+```sh
+gzip release-1.tar
+gzip release-2.tar
+xdelta3 -e -s release-1.tar.gz release-2.tar.gz delta-1-2.xd3
+xdelta3 -d -s release-1.tar.gz delta-1-2.xd3 release-2.tar.gz
+```
+
+Because of these pitfalls, xdelta3 prints a warning when it auto-decompresses:
+
+```
+xdelta3: WARNING: the encoder is automatically decompressing the input file;
+xdelta3: WARNING: the decoder will automatically recompress the output file;
+xdelta3: WARNING: this may result in different compressed data and checksums
+xdelta3: WARNING: despite being identical data; if this is an issue, use -D
+xdelta3: WARNING: to avoid decompression and/or use -R to avoid recompression
+xdelta3: WARNING: and/or manually decompress the input file; if you know the
+xdelta3: WARNING: compression settings that will produce identical output
+xdelta3: WARNING: you may set those flags using the environment (e.g., GZIP=-9)
+```
+
+!!! note "Interaction with armor mode"
+    [Armor mode](armor.md) digests cover the logical (decompressed) content
+    xdelta3 processes, not the raw on-disk bytes, so whole-file verification
+    composes correctly with external decompression of inputs and recompression
+    of output.

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -1,0 +1,52 @@
+# Xdelta
+
+Xdelta is a command-line tool and C library for **differential compression**:
+it computes and applies binary deltas between files using the
+[VCDIFF/RFC 3284](https://www.rfc-editor.org/rfc/rfc3284.txt) format. It is well
+suited to distributing updates, since a delta between two similar files is
+typically far smaller than the files themselves.
+
+This is the documentation for **Xdelta version 3** (the maintained 3.2.x
+series). The sources live at <https://github.com/jmacd/xdelta>.
+
+## Quick start
+
+Create a patch from `old_file` to `new_file`:
+
+```sh
+xdelta3 -e -s old_file new_file delta_file
+```
+
+Apply the patch to reconstruct `new_file`:
+
+```sh
+xdelta3 -d -s old_file delta_file decoded_new_file
+```
+
+Run `xdelta3 -h` for brief help and `xdelta3 test` for the built-in self test.
+
+## Highlights
+
+- VCDIFF (RFC 3284) encoding and decoding, with 64-bit file support on Linux,
+  macOS, Windows, and other platforms.
+- Optional secondary compression: `lzma` (when built with liblzma), plus the
+  built-in `djw` and `fgk` coders. See
+  [Better compression](better-compression.md).
+- [Armor mode](armor.md): whole-file [BLAKE3](https://github.com/BLAKE3-team/BLAKE3)
+  verification embedded in the delta, on by default, so applying a patch with
+  the wrong source fails fast with a clear message.
+- A stable streaming C API for embedding. See the
+  [Programming guide](programming-guide.md).
+
+## Where to go next
+
+- [Command-line syntax](commandline.md) — the full option reference.
+- [Armor mode](armor.md) — how whole-file verification works.
+- [Tuning the memory budget](tuning-memory.md) — `-B`, `-W`, `-I`, `-P`.
+- [Programming guide](programming-guide.md) — the encode/decode API.
+- [Licensing](licensing.md) — the maintained branches are Apache 2.0.
+
+!!! note "History"
+    Xdelta 1.x (first released in 1999) and the original GPL-licensed Xdelta 3
+    are no longer maintained here. The GPL line lives at
+    <https://github.com/jmacd/xdelta-gpl>.

--- a/site/docs/language-interface.md
+++ b/site/docs/language-interface.md
@@ -1,0 +1,42 @@
+# Language interfaces
+
+!!! note "Historical"
+    The bindings described here date from the Xdelta 3.0 era and are not built
+    or tested by the current CMake-based sources. They are documented for
+    reference. For embedding xdelta3 today, use the C API directly (see the
+    [Programming guide](programming-guide.md)).
+
+## Scripting languages
+
+A Python module named `xdelta3main` installed via `setup.py` and supported a
+single method, `xdelta3main.xd3_main_cmdline()`, which ran the `xdelta3`
+`main()` without `os.fork()` / `os.execl()`.
+
+The [SWIG](https://www.swig.org/)-generated `xdelta3` module exported
+`xdelta3.xd3_encode_memory()`, `xdelta3.xd3_decode_memory()`, and
+`xdelta3.xd3_main_cmdline()`. The historical `xdelta3-test.py` and
+`xdelta3-regtest.py` showed example usage:
+
+```python
+import xdelta3
+
+# in-memory interface
+source = 'source source input0 source source'
+target = 'source source target source source'
+
+result1, patch   = xdelta3.xd3_encode_memory(target, source, len(target))
+result2, target1 = xdelta3.xd3_decode_memory(patch, source, len(target))
+
+assert result1 == 0
+assert result2 == 0
+assert target1 == target
+assert len(patch) < len(target)
+
+# command-line interface
+source_file = ...
+target_file = ...
+command_args = ['xdelta3', '-f', '-s', source_file, target_file, output_file]
+
+xdelta3.xd3_main_cmdline(command_args)
+# same as xdelta3main.xd3_main_cmdline(command_args)
+```

--- a/site/docs/licensing.md
+++ b/site/docs/licensing.md
@@ -1,0 +1,16 @@
+# Licensing
+
+The maintained Xdelta 3.x branches in this repository — `main` and the
+`release3_*_apl` release branches — are licensed under the
+[Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0). The
+original author re-licensed these sources under the APL; see the `LICENSE` file
+in the repository.
+
+You may use, distribute, and embed these Apache-licensed sources (including
+linking against the library API) under the terms of the Apache License 2.0.
+
+!!! warning "The original GPL line is separate"
+    Earlier Xdelta releases were distributed under the GNU GPL version 2. That
+    GPL-licensed line lives separately at
+    <https://github.com/jmacd/xdelta-gpl> and is **not** covered by the Apache
+    license described here. Make sure you know which sources you are using.

--- a/site/docs/non-seekable-source.md
+++ b/site/docs/non-seekable-source.md
@@ -1,0 +1,35 @@
+# Non-seekable source files
+
+How to compress when the **source** is a stream, named pipe, or FIFO rather
+than a regular file.
+
+## Overview
+
+It is possible to read the source file from a FIFO or named pipe. The encoder is
+designed not to seek backward in the source, but this has implications for the
+decoder's memory budget.
+
+## Details
+
+The source window size (set by `-B`) used by the **decoder** must be **greater
+than or equal to** the source window size used by the **encoder**. If a copy
+references source data further back than the decoder's window allows, you will
+see:
+
+```
+xdelta3: non-seekable source: copy is too far back (try raising -B): XD3_INTERNAL
+```
+
+Raise `-B` (see [Tuning the memory budget](tuning-memory.md)) so the decoder
+keeps enough of the source in memory.
+
+This non-seekable mode is the default for
+[external compression](external-compression.md): when you pass a compressed
+source file on the command line, xdelta3 forks the decompression command and
+reads the source through a pipe.
+
+!!! note "Armor mode requires a seekable source"
+    [Armor mode](armor.md) (on by default) reads the source in full to compute
+    and verify its BLAKE3 digest, which requires a seekable (regular) file. With
+    a non-seekable source the decoder cannot verify it up front, so it warns and
+    proceeds; pass `-a` to disable armor for fully streaming use.

--- a/site/docs/programming-guide.md
+++ b/site/docs/programming-guide.md
@@ -1,0 +1,148 @@
+# Programming guide
+
+This guide is a quick start to the Xdelta3 C programming interface. It is not a
+complete reference — the comments in `xdelta3.h` and the command-line
+application in `xdelta3-main.h` offer more detail.
+
+## Simple API
+
+Two convenience functions encode to and decode from in-memory buffers: see
+`xd3_encode_memory` and `xd3_decode_memory`.
+
+## Advanced API
+
+There are three external structures, two of which are discussed here:
+
+- **`xd3_stream`** plays the main role: it holds the state needed to encode or
+  decode one stream of data.
+- **`xd3_source`** maintains state about the optional source file against which
+  differences are computed.
+- **`xd3_config`** configures encoder parameters.
+
+At a glance the interface resembles Zlib. The program puts data in, which the
+`xd3_stream` consumes. After computing over the data, the stream produces output
+for the application to consume, or requests more input. The stream also asks the
+application to read a block of source data. That request can be handled two
+ways: if an `xd3_getblk` callback is provided, the library calls it and suspends
+computation until it completes; if no callback is provided, the library returns
+a special code (`XD3_GETSRCBLK`) so the application can issue the request and
+resume whenever it likes. In both cases the `xd3_source` struct carries the
+requested block number and a place to store the result.
+
+## Setup
+
+Declare and initialize the `xd3_stream`:
+
+```c
+int ret;
+xd3_stream stream;
+xd3_config config;
+
+xd3_init_config(&config, 0 /* flags */);
+config.winsize = 32768;
+ret = xd3_config_stream(&stream, &config);
+
+if (ret != 0) { /* error */ }
+```
+
+`xd3_init_config()` fills `xd3_config` with default values. The most relevant
+setting, `xd3_config.winsize`, sets the encoder window size; the encoder
+allocates a buffer of this size when the program supplies input in smaller units
+(unless the `XD3_FLUSH` flag is set). `xd3_config_stream()` initializes the
+`xd3_stream` with the supplied configuration.
+
+## Setting the source
+
+The stream is ready for input now, though for encoding the source must be
+supplied first. Declare and initialize the `xd3_source`:
+
+```c
+xd3_source source;
+void *IO_handle = ...;
+
+source.name     = "...";
+source.size     = file_size;
+source.ioh      = IO_handle;
+source.blksize  = 32768;
+source.curblkno = (xoff_t) -1;
+source.curblk   = NULL;
+
+ret = xd3_set_source(&stream, &source);
+
+if (ret != 0) { /* error */ }
+```
+
+The decoder sets the source the same way, but may delay until the application
+header has been received (`XD3_GOTHEADER`). An application can check whether
+source data is required for decoding with `xd3_decoder_needs_source()`.
+
+`xd3_source.blksize` is the block size used for requesting source blocks. If the
+first source block (or the entire source) is already in memory, set `curblkno`
+to `0` and `curblk` to that block of data.
+
+## Input/output loop
+
+The application provides input by calling `xd3_avail_input()`, then drives
+encoding or decoding with one of:
+
+```c
+int xd3_encode_input(xd3_stream *stream);
+int xd3_decode_input(xd3_stream *stream);
+```
+
+Barring an error, these return one of six result codes the application must
+handle. Much of the handling is shared between encoding and decoding:
+
+- **`XD3_INPUT`** — the stream is ready for (or requires) more input. Call
+  `xd3_avail_input` when more data is available.
+- **`XD3_OUTPUT`** — the stream has pending output. Consume the block in
+  `next_out` / `avail_out`, then call `xd3_consume_output`.
+- **`XD3_GETSRCBLK`** — the stream is requesting a source block (only returned
+  when no `xd3_getblk` callback was provided).
+- **`XD3_GOTHEADER`** — decoder-specific: the first VCDIFF window header has
+  been received, a chance to inspect the application header.
+- **`XD3_WINSTART`** — returned by encoder and decoder before processing a
+  window. For encoding, once there is enough input; for decoding, after each
+  window header (except the first, which yields `XD3_GOTHEADER`).
+- **`XD3_WINFINISH`** — the output for a single window has been fully consumed.
+
+An application can be structured like this:
+
+```c
+do {
+  read(&indata, &insize);
+  if (reached_EOF) {
+    xd3_set_flags(&stream, XD3_FLUSH);
+  }
+  xd3_avail_input(&stream, indata, insize);
+process:
+  ret = xd3_xxcode_input(&stream);   /* encode or decode */
+  switch (ret) {
+  case XD3_INPUT:
+    continue;
+  case XD3_OUTPUT:
+    /* write data */
+    goto process;
+  case XD3_GETSRCBLK:
+    /* set source block */
+    goto process;
+  case XD3_GOTHEADER:
+  case XD3_WINSTART:
+  case XD3_WINFINISH:
+    /* no action necessary */
+    goto process;
+  default:
+    /* error */
+  }
+} while (! reached_EOF);
+```
+
+Finally, close and free the stream. `xd3_close_stream()` checks several error
+conditions but performs no I/O; `xd3_free_stream()` frees all memory the stream
+allocated.
+
+## Application header
+
+Two routines get and set the application header. When encoding, set it before
+the first `XD3_WINSTART`. When decoding, it is available after the first
+`XD3_GOTHEADER`.

--- a/site/docs/projects.md
+++ b/site/docs/projects.md
@@ -1,0 +1,16 @@
+# Projects using Xdelta3
+
+!!! note "Historical"
+    This list is preserved from the original project wiki and is not actively
+    maintained. Some links may be dead. To add or update an entry, open a pull
+    request against `site/docs/projects.md`.
+
+## Open-source projects using the Xdelta3 API
+
+- **Zumastor** — Linux storage replication used the xdelta3 API. (The original
+  `code.google.com/p/zumastor` project page is no longer available.)
+
+## Open-source projects using VCDIFF
+
+- A C# VCDIFF decoder by Jon Skeet, formerly distributed as part of his
+  `MiscUtil` library.

--- a/site/docs/tuning-memory.md
+++ b/site/docs/tuning-memory.md
@@ -1,0 +1,70 @@
+# Tuning the memory budget
+
+There are five memory-cost parameters that determine compression performance,
+independent of compression level. The code was designed to work with a fixed
+memory budget regardless of input size; poor compression can result from an
+insufficient budget. Defaults are automatically lowered for small files.
+
+!!! note "Units"
+    All flags are set in **bytes**. For example, a 512 MB source buffer is
+    `-B536870912`.
+
+## Source buffer size (`-B`)
+
+The encoder uses a buffer for the source input (size set by `-B`). To ensure the
+source is read sequentially with no backward seeks, the encoder keeps the source
+*horizon* half the source buffer size ahead of the input position. A source copy
+will not be found if it lies more than half the source buffer size away from its
+absolute position in the input stream.
+
+For large files, `-B` may need to be raised. The default is 64 MB, which means
+data should not shift more than 32 MB — that is, no more than 32 MB should be
+added or removed relative to the source. The minimum is 16 KB. The source file
+is read into the buffer; it is not `mmap`ed (Xdelta 1.x used `mmap()`).
+
+## Input window size (`-W`)
+
+The input window size (`-W`) determines how much input is compressed in a single
+VCDIFF window. Smaller windows have higher compression cost and take less memory
+to decode. Larger windows give better compression, but only up to a point, since
+large-window addresses take more bits to encode. The default is 8 MB, the
+minimum 16 KB, and the maximum 16 MB.
+
+## Instruction buffer size (`-I`)
+
+The instruction buffer stores potential, possibly overlapping, copy instructions
+while the encoder looks ahead. Set its size with `-I size` (default 32K slots);
+`-I 0` selects an unlimited buffer.
+
+An unencoded instruction occupies 28 bytes, so a bounded buffer has advantages.
+On the other hand, the minimum and maximum source addresses must be decided
+before encoding the first instruction, so letting the buffer fill before a
+window finishes can hurt compression for the rest of the window.
+
+## Compression duplicates size (`-P`)
+
+The compressor uses an array of duplicate positions (`-P`) to find better
+matches in the **target** (not the source). This should be less than or equal to
+the input window size (`-W`). The default is 256K slots.
+
+## Compression level (`-0` … `-9`)
+
+The compression level sizes two internal data structures. `-9` uses about four
+times as much memory as `-1`.
+
+## Decoder memory requirements
+
+To decode, `-B` and `-W` are used much as for encoding. For the source buffer,
+the decoder uses the smaller of `-B` or the source file size. Setting `-B`
+smaller than the value used to encode causes seeking, served by an LRU cache of
+blocks.
+
+The input buffer is sized according to `-W`. In addition, the decoder allocates
+three buffers for the data, address, and instruction sections of a VCDIFF
+window; their sizes depend on the compressed size of a window and therefore on
+the encoder's `-W`. If secondary compression is used, an extra set of buffers is
+allocated for each secondary-compressed section.
+
+In summary, decoding uses `-B` bytes for the source buffer, plus `-W` bytes for
+its input buffer, plus three or six buffers totaling no more than one or two
+times the encoder's `-W` (depending on secondary compression).

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -1,0 +1,63 @@
+site_name: Xdelta
+site_description: VCDIFF (RFC 3284) delta compression library and command-line tool
+site_url: https://jmacd.github.io/xdelta/
+repo_url: https://github.com/jmacd/xdelta
+repo_name: jmacd/xdelta
+edit_uri: edit/main/site/docs/
+copyright: Licensed under the Apache License, Version 2.0.
+
+# MkDocs builds into ./_site so it does not collide with the ./site source dir.
+site_dir: _site
+
+theme:
+  name: material
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.top
+    - content.code.copy
+    - content.action.edit
+    - search.highlight
+    - toc.follow
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
+
+markdown_extensions:
+  - admonition
+  - toc:
+      permalink: true
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.superfences
+  - pymdownx.inlinehilite
+  - tables
+
+nav:
+  - Home: index.md
+  - Using xdelta3:
+      - Command-line syntax: commandline.md
+      - Armor mode: armor.md
+      - External compression: external-compression.md
+      - Non-seekable source files: non-seekable-source.md
+      - Tuning the memory budget: tuning-memory.md
+      - "Better compression (secondary)": better-compression.md
+      - "\"Target window checksum mismatch\" explained": checksum-mismatch.md
+  - Developing with xdelta3:
+      - Programming guide: programming-guide.md
+      - Language interfaces: language-interface.md
+  - Project:
+      - Licensing: licensing.md
+      - Projects using Xdelta3: projects.md

--- a/site/requirements.txt
+++ b/site/requirements.txt
@@ -1,0 +1,2 @@
+# Pinned for reproducible site builds (CI and local).
+mkdocs-material==9.5.39


### PR DESCRIPTION
Migrate the legacy `wiki` branch pages into a MkDocs + Material site in a top-level `site/` directory and update them for the current 3.2.x sources.

## What's included
- `site/` with `mkdocs.yml` (Material theme, nav, search), `requirements.txt`, and a build README; the 11 wiki pages are migrated into `site/docs/`.
- **New `armor.md`** documenting armor mode (whole-file BLAKE3 verification), which the old wiki predated.
- `commandline.md` reflects the current `xdelta3 -h` (`merge`/`recode`, `-a`, `-S lzma`, `-F`/`-P`/`-I`/`-J`, `XDELTA` env var, exit-status table), incorporating the updates proposed in #257.
- `checksum-mismatch.md` notes armor's up-front whole-file verification; `licensing.md` corrected from GPLv2 to **Apache 2.0** (GPL only on xdelta-gpl); dead code.google.com links fixed; SWIG/Python bindings and the project list marked historical.
- `.github/workflows/site.yml` builds (strict) on PRs and deploys to GitHub Pages on push to `main`; the `site/_site` build output is ignored.
- README Documentation section points to https://jmacd.github.io/xdelta/.

## Notes
- Supersedes #257 (its CLI additions are folded into `commandline.md`).
- Requires the repo Pages source set to "GitHub Actions" (already applied).
