### PR TITLE
Rename Q/W/Z printf-length macros to XD3_Q/XD3_W/XD3_Z (#292)

### DIFF
--- a/xdelta3/testing/checksum_test.cc
+++ b/xdelta3/testing/checksum_test.cc
@@ -404,17 +404,17 @@ template <typename Checksum> struct test_result : public test_result_base {
 
   void print() {
     if (fstats.count != count()) {
-      fprintf(stderr, "internal error: %" W "d != %" W "d\n", fstats.count,
-              count());
+      fprintf(stderr, "internal error: %" XD3_W "d != %" XD3_W "d\n",
+              fstats.count, count());
       abort();
     }
     print_header();
-    printf("%-32s%d/%d 2^%" W "u\t%" W "u\t%0.4f\t%.4f\t%.4f\t%.1e\t%.2f\t"
-           "%" W "u\t%" W "u\n",
-           test_name, Checksum::cksum_size, Checksum::cksum_skip, h_bits,
-           count(), uniqueness(), fullness(), coverage(), collisions(),
-           0.001 * accum_iters * test_size / accum_millis, accum_iters,
-           colls());
+    printf(
+        "%-32s%d/%d 2^%" XD3_W "u\t%" XD3_W "u\t%0.4f\t%.4f\t%.4f\t%.1e\t%.2f\t"
+        "%" XD3_W "u\t%" XD3_W "u\n",
+        test_name, Checksum::cksum_size, Checksum::cksum_skip, h_bits, count(),
+        uniqueness(), fullness(), coverage(), collisions(),
+        0.001 * accum_iters * test_size / accum_millis, accum_iters, colls());
   }
 
   usize_t size_log2(usize_t slots) {

--- a/xdelta3/testing/delta.h
+++ b/xdelta3/testing/delta.h
@@ -63,13 +63,13 @@ public:
   //       xd3_winst &winst = stream_.whole_target.inst[i];
   //       switch (winst.type) {
   //       case XD3_RUN:
-  // 	DP(RINT, "%" Q "u run %" W "u\n", winst.position, winst.size);
+  // 	DP(RINT, "%" XD3_Q "u run %" XD3_W "u\n", winst.position, winst.size);
   // 	break;
   //       case XD3_ADD:
-  // 	DP(RINT "%" Q "u add %" W "u\n", winst.position, winst.size);
+  // 	DP(RINT "%" XD3_Q "u add %" XD3_W "u\n", winst.position, winst.size);
   // 	break;
   //       default:
-  // 	DP(RINT "%" Q "u copy %" W "u @ %" Q "u (mode %u)\n",
+  // 	DP(RINT "%" XD3_Q "u copy %" XD3_W "u @ %" XD3_Q "u (mode %u)\n",
   // 	   winst.position, winst.size, winst.addr, winst.mode);
   // 	break;
   //       }

--- a/xdelta3/testing/file.h
+++ b/xdelta3/testing/file.h
@@ -75,7 +75,7 @@ public:
   //   xoff_t pos = 0;
   //   for (size_t i = 0; i < Size(); i++) {
   //     if (pos % 16 == 0) {
-  // 	DP(RINT "%5" Q "x: ", pos);
+  // 	DP(RINT "%5" XD3_Q "x: ", pos);
   //     }
   //     DP(RINT "%02x ", (*this)[i]);
   //     if (pos % 16 == 15) {
@@ -293,7 +293,7 @@ public:
     pid_t pid = getpid();
     char buf[64];
     xoff_t xpid = pid;
-    snprintf(buf, 64, "/tmp/regtest.%" Q "u.%d", xpid, static_counter++);
+    snprintf(buf, 64, "/tmp/regtest.%" XD3_Q "u.%d", xpid, static_counter++);
     filename_.append(buf);
     unlink(filename_.c_str());
   }

--- a/xdelta3/testing/regtest.cc
+++ b/xdelta3/testing/regtest.cc
@@ -99,8 +99,8 @@ public:
     bool done = false;
     bool done_after_input = false;
 
-    IF_DEBUG1(XPR(NTR "source %" Q "u[%" Z "u] target %" Q "u winsize %" Z
-                      "u\n",
+    IF_DEBUG1(XPR(NTR "source %" XD3_Q "u[%" XD3_Z "u] target %" XD3_Q
+                      "u winsize %" XD3_Z "u\n",
                   source_file.Size(), options.block_size, target_file.Size(),
                   Constants::WINDOW_SIZE));
 
@@ -109,11 +109,11 @@ public:
 
       xoff_t blks = target_iterator.Blocks();
 
-      IF_DEBUG2(XPR(NTR "target in %s: %" Q "u[%" Z "u] %" Q "u(%" Q "u) "
-                        "verified %" Q "u\n",
-                    encoding ? "encoding" : "decoding",
-                    target_iterator.Offset(), target_block.Size(),
-                    target_iterator.Blkno(), blks, verified_bytes));
+      IF_DEBUG2(XPR(
+          NTR "target in %s: %" XD3_Q "u[%" XD3_Z "u] %" XD3_Q "u(%" XD3_Q "u) "
+              "verified %" XD3_Q "u\n",
+          encoding ? "encoding" : "decoding", target_iterator.Offset(),
+          target_block.Size(), target_iterator.Blkno(), blks, verified_bytes));
 
       if (blks == 0 || target_iterator.Blkno() == (blks - 1)) {
         xd3_set_flags(&encode_stream, XD3_FLUSH | encode_stream.flags);
@@ -156,8 +156,8 @@ public:
         xd3_source *src = (encoding ? &encode_source : &decode_source);
         Block *block = (encoding ? &encode_source_block : &decode_source_block);
         if (encoding) {
-          IF_DEBUG2(XPR(NTR "[srcblock] %" Q "u last srcpos %" Q "u "
-                            "encodepos %" Q "u\n",
+          IF_DEBUG2(XPR(NTR "[srcblock] %" XD3_Q "u last srcpos %" XD3_Q "u "
+                            "encodepos %" XD3_Q "u\n",
                         encode_source.getblkno, encode_stream.match_last_srcpos,
                         encode_stream.input_position + encode_stream.total_in));
         }
@@ -229,7 +229,7 @@ public:
                         ExtFile *coded_data, const Options &options) {
     vector<const char *> ecmd;
     char bbuf[16];
-    snprintf(bbuf, sizeof(bbuf), "-B%" Q "u", options.encode_srcwin_maxsz);
+    snprintf(bbuf, sizeof(bbuf), "-B%" XD3_Q "u", options.encode_srcwin_maxsz);
     ecmd.push_back("xdelta3");
     ecmd.push_back(bbuf);
     ecmd.push_back("-s");
@@ -341,7 +341,7 @@ public:
   void TestPrintf() {
     char buf[64];
     xoff_t x = XOFF_T_MAX;
-    snprintf_func(buf, sizeof(buf), "%" Q "u", x);
+    snprintf_func(buf, sizeof(buf), "%" XD3_Q "u", x);
     const char *expect =
         XD3_USE_LARGEFILE64 ? "18446744073709551615" : "4294967295";
     XD3_ASSERT(strcmp(buf, expect) == 0);
@@ -784,7 +784,7 @@ public:
       InMemoryEncodeDecode(spec0, spec1, &block, options);
       Delta delta(block);
 
-      IF_DEBUG1(DP(RINT "[stride=%d] changes=%" W "u adds=%" Q "u\n", s,
+      IF_DEBUG1(DP(RINT "[stride=%d] changes=%" XD3_W "u adds=%" XD3_Q "u\n", s,
                    changes, delta.AddedBytes()));
       double allowance = Constants::BLOCK_SIZE < 8192 || s < 30 ? 3.0 : 1.1;
       CHECK_GE(allowance * changes, (double)delta.AddedBytes());
@@ -1217,7 +1217,7 @@ template <class T> void UnitTest() {
 
 // These are Xdelta tests.
 template <class T> void MainTest() {
-  XPR(NT "Blocksize %" Q "u windowsize %" Z "u\n", T::BLOCK_SIZE,
+  XPR(NT "Blocksize %" XD3_Q "u windowsize %" XD3_Z "u\n", T::BLOCK_SIZE,
       T::WINDOW_SIZE);
   Regtest<T> regtest;
   TEST(TestEmptyInMemory);

--- a/xdelta3/xdelta3-blkcache.h
+++ b/xdelta3/xdelta3-blkcache.h
@@ -227,7 +227,7 @@ static int main_set_source(xd3_stream *stream, xd3_cmd cmd, main_file *sfile,
     static shortbuf nbufs;
 
     if (sfile->size_known) {
-      short_sprintf(srcszbuf, "source size %s [%" Q "u]",
+      short_sprintf(srcszbuf, "source size %s [%" XD3_Q "u]",
                     main_format_bcnt(source_size, &srccntbuf), source_size);
     } else {
       short_sprintf(srcszbuf, "%s", "source size unknown");
@@ -236,7 +236,7 @@ static int main_set_source(xd3_stream *stream, xd3_cmd cmd, main_file *sfile,
     nbufs.buf[0] = 0;
 
     if (option_verbose > 1) {
-      short_sprintf(nbufs, " #bufs %" W "u", lru_size);
+      short_sprintf(nbufs, " #bufs %" XD3_W "u", lru_size);
     }
 
     XPR(NT "source %s %s blksize %s window %s%s%s\n", sfile->filename,
@@ -275,12 +275,14 @@ static int main_getblk_lru(xd3_source *source, xoff_t blkno,
         main_blklru_list_remove(blru);
         main_blklru_list_push_back(&lru_list, blru);
         (*blrup) = blru;
-        IF_DEBUG1(DP(RINT "[getblk_lru] HIT blkno = %" Q "u lru_size=%" W "u\n",
+        IF_DEBUG1(DP(RINT "[getblk_lru] HIT blkno = %" XD3_Q
+                          "u lru_size=%" XD3_W "u\n",
                      blkno, lru_size));
         return 0;
       }
     }
-    IF_DEBUG1(DP(RINT "[getblk_lru] MISS blkno = %" Q "u lru_size=%" W "u\n",
+    IF_DEBUG1(DP(RINT "[getblk_lru] MISS blkno = %" XD3_Q "u lru_size=%" XD3_W
+                      "u\n",
                  blkno, lru_size));
   }
 
@@ -325,7 +327,7 @@ static int main_read_seek_source(xd3_stream *stream, xd3_source *source,
        * because of do_src_fifo during encode. */
       if (!option_quiet) {
         XPR(NT "source can't seek backwards; requested block offset "
-               "%" Q "u source position is %" Q "u\n",
+               "%" XD3_Q "u source position is %" XD3_Q "u\n",
             pos, sfile->source_position);
       }
 
@@ -342,14 +344,15 @@ static int main_read_seek_source(xd3_stream *stream, xd3_source *source,
       XPR(NT "source can't seek, will use FIFO for %s\n", sfile->filename);
 
       if (option_verbose > 1) {
-        XPR(NT "seek error at offset %" Q "u: %s\n", pos, xd3_mainerror(ret));
+        XPR(NT "seek error at offset %" XD3_Q "u: %s\n", pos,
+            xd3_mainerror(ret));
       }
     }
 
     sfile->seek_failed = 1;
 
     if (option_verbose > 1 && pos != sfile->source_position) {
-      XPR(NT "non-seekable source skipping %" Q "u bytes @ %" Q "u\n",
+      XPR(NT "non-seekable source skipping %" XD3_Q "u bytes @ %" XD3_Q "u\n",
           pos - sfile->source_position, sfile->source_position);
     }
 
@@ -378,7 +381,7 @@ static int main_read_seek_source(xd3_stream *stream, xd3_source *source,
 
       if (nread != source->blksize) {
         IF_DEBUG1(
-            DP(RINT "[getblk] short skip block nread = %" Z "u\n", nread));
+            DP(RINT "[getblk] short skip block nread = %" XD3_Z "u\n", nread));
         stream->msg = "non-seekable input is short";
         return XD3_INVALID_INPUT;
       }
@@ -386,7 +389,7 @@ static int main_read_seek_source(xd3_stream *stream, xd3_source *source,
       sfile->source_position += nread;
       blru->size = nread;
 
-      IF_DEBUG1(DP(RINT "[getblk] skip blkno %" Q "u size %" W "u\n",
+      IF_DEBUG1(DP(RINT "[getblk] skip blkno %" XD3_Q "u size %" XD3_W "u\n",
                    skip_blkno, blru->size));
 
       XD3_ASSERT(sfile->source_position <= pos);
@@ -457,16 +460,18 @@ static int main_getblk_func(xd3_stream *stream, xd3_source *source,
   if (option_verbose > 3) {
     if (blru->blkno != XD3_INVALID_OFFSET) {
       if (blru->blkno != blkno) {
-        XPR(NT "source block %" Q "u read %" Z "u ejects %" Q "u (lru_hits=%u, "
+        XPR(NT "source block %" XD3_Q "u read %" XD3_Z "u ejects %" XD3_Q
+               "u (lru_hits=%u, "
                "lru_misses=%u, lru_filled=%u)\n",
             blkno, nread, blru->blkno, lru_hits, lru_misses, lru_filled);
       } else {
-        XPR(NT "source block %" Q "u read %" Z "u (lru_hits=%u, "
+        XPR(NT "source block %" XD3_Q "u read %" XD3_Z "u (lru_hits=%u, "
                "lru_misses=%u, lru_filled=%u)\n",
             blkno, nread, lru_hits, lru_misses, lru_filled);
       }
     } else {
-      XPR(NT "source block %" Q "u read %" Z "u (lru_hits=%u, lru_misses=%u, "
+      XPR(NT "source block %" XD3_Q "u read %" XD3_Z
+             "u (lru_hits=%u, lru_misses=%u, "
              "lru_filled=%u)\n",
           blkno, nread, lru_hits, lru_misses, lru_filled);
     }
@@ -478,8 +483,9 @@ static int main_getblk_func(xd3_stream *stream, xd3_source *source,
   blru->size = nread;
   blru->blkno = blkno;
 
-  IF_DEBUG1(DP(RINT "[main_getblk] blkno %" Q "u onblk %" Z "u pos %" Q "u "
-                    "srcpos %" Q "u\n",
+  IF_DEBUG1(DP(RINT "[main_getblk] blkno %" XD3_Q "u onblk %" XD3_Z
+                    "u pos %" XD3_Q "u "
+                    "srcpos %" XD3_Q "u\n",
                blkno, nread, pos, sfile->source_position));
 
   return 0;

--- a/xdelta3/xdelta3-decode.h
+++ b/xdelta3/xdelta3-decode.h
@@ -140,8 +140,9 @@ static int xd3_decode_setup_buffers(xd3_stream *stream) {
 
 static int xd3_decode_allocate(xd3_stream *stream, usize_t size,
                                uint8_t **buf_ptr, usize_t *buf_alloc) {
-  IF_DEBUG2(DP(RINT "[xd3_decode_allocate] size %" W "u alloc %" W "u\n", size,
-               *buf_alloc));
+  IF_DEBUG2(DP(RINT "[xd3_decode_allocate] size %" XD3_W "u alloc %" XD3_W
+                    "u\n",
+               size, *buf_alloc));
 
   if (*buf_ptr != NULL && *buf_alloc < size) {
     xd3_free(stream, *buf_ptr);
@@ -175,8 +176,8 @@ static int xd3_decode_section(xd3_stream *stream, xd3_desect *section,
       /* No allocation/copy needed */
       section->buf = stream->next_in;
       sect_take = section->size;
-      IF_DEBUG1(DP(RINT "[xd3_decode_section] zerocopy %" W "u @ %" W
-                        "u avail %" W "u\n",
+      IF_DEBUG1(DP(RINT "[xd3_decode_section] zerocopy %" XD3_W "u @ %" XD3_W
+                        "u avail %" XD3_W "u\n",
                    sect_take, section->pos, stream->avail_in));
     } else {
       usize_t sect_need = section->size - section->pos;
@@ -195,8 +196,8 @@ static int xd3_decode_section(xd3_stream *stream, xd3_desect *section,
         section->buf = section->copied1;
       }
 
-      IF_DEBUG2(DP(RINT "[xd3_decode_section] take %" W "u @ %" W "u [need %" W
-                        "u] avail %" W "u\n",
+      IF_DEBUG2(DP(RINT "[xd3_decode_section] take %" XD3_W "u @ %" XD3_W
+                        "u [need %" XD3_W "u] avail %" XD3_W "u\n",
                    sect_take, section->pos, sect_need, stream->avail_in));
       XD3_ASSERT(section->pos + sect_take <= section->alloc1);
 
@@ -211,7 +212,8 @@ static int xd3_decode_section(xd3_stream *stream, xd3_desect *section,
   }
 
   if (section->pos < section->size) {
-    IF_DEBUG1(DP(RINT "[xd3_decode_section] further input required %" W "u\n",
+    IF_DEBUG1(DP(RINT "[xd3_decode_section] further input required %" XD3_W
+                      "u\n",
                  section->size - section->pos));
     stream->msg = "further input required";
     return XD3_INPUT;
@@ -244,8 +246,8 @@ static int xd3_decode_parse_halfinst(xd3_stream *stream, xd3_hinst *inst) {
   if (inst->type >= XD3_CPY) {
     IF_DEBUG2({
       static int cnt = 0;
-      XPR(NT "DECODE:%u: COPY at %" Q "u (winoffset %" W "u) "
-             "size %" W "u winaddr %" W "u\n",
+      XPR(NT "DECODE:%u: COPY at %" XD3_Q "u (winoffset %" XD3_W "u) "
+             "size %" XD3_W "u winaddr %" XD3_W "u\n",
           cnt++,
           stream->total_out + (stream->dec_position - stream->dec_cpylen),
           (stream->dec_position - stream->dec_cpylen), inst->size, inst->addr);
@@ -274,14 +276,16 @@ static int xd3_decode_parse_halfinst(xd3_stream *stream, xd3_hinst *inst) {
     IF_DEBUG2({
       if (inst->type == XD3_ADD) {
         static int cnt;
-        XPR(NT "DECODE:%d: ADD at %" Q "u (winoffset %" W "u) size %" W "u\n",
+        XPR(NT "DECODE:%d: ADD at %" XD3_Q "u (winoffset %" XD3_W
+               "u) size %" XD3_W "u\n",
             cnt++,
             (stream->total_out + stream->dec_position - stream->dec_cpylen),
             stream->dec_position - stream->dec_cpylen, inst->size);
       } else {
         static int cnt;
         XD3_ASSERT(inst->type == XD3_RUN);
-        XPR(NT "DECODE:%d: RUN at %" Q "u (winoffset %" W "u) size %" W "u\n",
+        XPR(NT "DECODE:%d: RUN at %" XD3_Q "u (winoffset %" XD3_W
+               "u) size %" XD3_W "u\n",
             cnt++,
             stream->total_out + stream->dec_position - stream->dec_cpylen,
             stream->dec_position - stream->dec_cpylen, inst->size);
@@ -440,9 +444,9 @@ static int xd3_decode_output_halfinst(xd3_stream *stream, xd3_hinst *inst) {
         /* This block is either full, or a partial block that
          * must contain enough bytes. */
         if ((source->onblk != blksize) && (blkoff + take > source->onblk)) {
-          IF_DEBUG1(XPR(NT "[srcfile] short at blkno %" Q "u onblk "
-                           "%" W "u blksize %" W "u blkoff %" W "u take %" W
-                           "u\n",
+          IF_DEBUG1(XPR(NT "[srcfile] short at blkno %" XD3_Q "u onblk "
+                           "%" XD3_W "u blksize %" XD3_W "u blkoff %" XD3_W
+                           "u take %" XD3_W "u\n",
                         block, source->onblk, blksize, blkoff, take));
           stream->msg = "source file too short";
           return XD3_INVALID_INPUT;
@@ -664,7 +668,7 @@ static int xd3_decode_emit(xd3_stream *stream) {
   }
 
   if (stream->avail_out != stream->dec_tgtlen) {
-    IF_DEBUG2(DP(RINT "AVAIL_OUT(%" W "u) != DEC_TGTLEN(%" W "u)\n",
+    IF_DEBUG2(DP(RINT "AVAIL_OUT(%" XD3_W "u) != DEC_TGTLEN(%" XD3_W "u)\n",
                  stream->avail_out, stream->dec_tgtlen));
     stream->msg = "wrong window length";
     return XD3_INVALID_INPUT;
@@ -881,7 +885,7 @@ int xd3_decode_input(xd3_stream *stream) {
 
     stream->dec_state = DEC_CPYLEN;
 
-    IF_DEBUG2(DP(RINT "--------- TARGET WINDOW %" Q "u -----------\n",
+    IF_DEBUG2(DP(RINT "--------- TARGET WINDOW %" XD3_Q "u -----------\n",
                  stream->current_window));
   }
 
@@ -1024,10 +1028,10 @@ int xd3_decode_input(xd3_stream *stream) {
       xd3_blksize_div(stream->dec_cpyoff, src, &src->cpyoff_blocks,
                       &src->cpyoff_blkoff);
 
-      IF_DEBUG2(DP(RINT "[decode_cpyoff] %" Q "u "
-                        "cpyblkno %" Q "u "
-                        "cpyblkoff %" W "u "
-                        "blksize %" W "u\n",
+      IF_DEBUG2(DP(RINT "[decode_cpyoff] %" XD3_Q "u "
+                        "cpyblkno %" XD3_Q "u "
+                        "cpyblkoff %" XD3_W "u "
+                        "blksize %" XD3_W "u\n",
                    stream->dec_cpyoff, src->cpyoff_blocks, src->cpyoff_blkoff,
                    src->blksize));
     }

--- a/xdelta3/xdelta3-djw.h
+++ b/xdelta3/xdelta3-djw.h
@@ -284,7 +284,7 @@ static void heap_check(usize_t *heap, djw_heapen *ents, usize_t heap_last) {
     /* Heap property: child not less than parent */
     XD3_ASSERT(!heap_less(&ents[heap[i]], &ents[heap[i / 2]]));
 
-    IF_DEBUG2(DP(RINT "heap[%" W "u] = %u\n", i, ents[heap[i]].freq));
+    IF_DEBUG2(DP(RINT "heap[%" XD3_W "u] = %u\n", i, ents[heap[i]].freq));
   }
 }
 #endif
@@ -360,8 +360,8 @@ static usize_t djw_build_prefix(const djw_weight *freq, uint8_t *clen,
   /* Insert real symbol frequences. */
   for (i = 0; i < asize; i += 1) {
     ents[i + 1].freq = freq[i];
-    IF_DEBUG2(
-        DP(RINT "ents[%" W "i] = freq[%" W "u] = %d\n", i + 1, i, freq[i]));
+    IF_DEBUG2(DP(RINT "ents[%" XD3_W "i] = freq[%" XD3_W "u] = %d\n", i + 1, i,
+                 freq[i]));
   }
 
 again:
@@ -437,7 +437,7 @@ again:
     }
 
     /* clen is 0-origin, unlike ents. */
-    IF_DEBUG2(DP(RINT "clen[%" W "u] = %" W "u\n", i - 1, b));
+    IF_DEBUG2(DP(RINT "clen[%" XD3_W "u] = %" XD3_W "u\n", i - 1, b));
     clen[i - 1] = (uint8_t)b;
   }
 
@@ -445,7 +445,7 @@ again:
 
   if (!overflow) {
     IF_DEBUG2(if (first_bits != total_bits) {
-      DP(RINT "code length overflow changed %" W "u bits\n",
+      DP(RINT "code length overflow changed %" XD3_W "u bits\n",
          total_bits - first_bits);
     });
     return total_bits;
@@ -491,7 +491,7 @@ static void djw_build_codes(usize_t *codes, const uint8_t *clen, usize_t asize,
 
   IF_DEBUG2({
     for (i = 0; i < asize; i += 1) {
-      DP(RINT "code[%" W "u] = %" W "u\n", i, codes[i]);
+      DP(RINT "code[%" XD3_W "u] = %" XD3_W "u\n", i, codes[i]);
     }
   });
 }
@@ -942,7 +942,8 @@ static int xd3_encode_huff(xd3_stream *stream, djw_stream *h, xd3_output *input,
        * case subtract one group and try again.  If (inefficient), we're
        * testing group behavior, so don't mess things up. */
       if (goal == 0 && !cfg->inefficient) {
-        IF_DEBUG2(DP(RINT "too many groups (%" W "u), dropping one\n", groups));
+        IF_DEBUG2(
+            DP(RINT "too many groups (%" XD3_W "u), dropping one\n", groups));
         groups -= 1;
         goto regroup;
       }
@@ -954,9 +955,9 @@ static int xd3_encode_huff(xd3_stream *stream, djw_stream *h, xd3_output *input,
         sum += real_freq[sym2++];
       }
 
-      IF_DEBUG2(DP(RINT "group %" W "u has symbols %" W "u..%" W "u (%" W
-                        "u non-zero) "
-                        "(%u/%" W "u = %.3f)\n",
+      IF_DEBUG2(DP(RINT "group %" XD3_W "u has symbols %" XD3_W "u..%" XD3_W
+                        "u (%" XD3_W "u non-zero) "
+                        "(%u/%" XD3_W "u = %.3f)\n",
                    gp, sym1, sym2, nz, sum, input_bytes,
                    sum / (double)input_bytes););
 
@@ -1075,21 +1076,22 @@ static int xd3_encode_huff(xd3_stream *stream, djw_stream *h, xd3_output *input,
           }
         }
 
-        IF_DEBUG2(DP(RINT "evolve_zero reduced %" W "u bits in group %" W "u\n",
+        IF_DEBUG2(DP(RINT "evolve_zero reduced %" XD3_W
+                          "u bits in group %" XD3_W "u\n",
                      save_total - output_bits, gp));
       }
     }
 
-    IF_DEBUG2(DP(RINT "pass %" W "u total bits: %" W "u group uses: ", niter,
-                 output_bits);
+    IF_DEBUG2(DP(RINT "pass %" XD3_W "u total bits: %" XD3_W "u group uses: ",
+                 niter, output_bits);
               for (gp = 0; gp < groups; gp += 1) {
-                DP(RINT "%" W "u ", gcount[gp]);
+                DP(RINT "%" XD3_W "u ", gcount[gp]);
               } DP(RINT "\n"););
 
     /* End iteration. */
 
     IF_DEBUG2(if (niter > 1 && best_bits < output_bits) {
-      DP(RINT "iteration lost %" W "u bits\n", output_bits - best_bits);
+      DP(RINT "iteration lost %" XD3_W "u bits\n", output_bits - best_bits);
     });
 
     if (niter == 1 || (niter < DJW_MAX_ITER &&
@@ -1103,7 +1105,7 @@ static int xd3_encode_huff(xd3_stream *stream, djw_stream *h, xd3_output *input,
       goto nosecond;
     }
 
-    IF_DEBUG2(DP(RINT "djw compression: %" W "u -> %0.3f\n", input_bytes,
+    IF_DEBUG2(DP(RINT "djw compression: %" XD3_W "u -> %0.3f\n", input_bytes,
                  output_bits / 8.0));
 
     /* Encode: prefix */
@@ -1358,7 +1360,7 @@ done:
     usize_t offset = code - base[bits];
 
     if (offset <= max_sym) {
-      IF_DEBUG2(DP(RINT "(j) %" W "u ", code));
+      IF_DEBUG2(DP(RINT "(j) %" XD3_W "u ", code));
       *sym = inorder[offset];
       return 0;
     }

--- a/xdelta3/xdelta3-main.h
+++ b/xdelta3/xdelta3-main.h
@@ -700,7 +700,7 @@ static const char *main_format_bcnt(xoff_t r, shortbuf *buf) {
     }
 
     if (r >= 100 && r < 1000) {
-      short_sprintf(*buf, "%" Q "u %s", r, fmts[i]);
+      short_sprintf(*buf, "%" XD3_Q "u %s", r, fmts[i]);
       return buf->buf;
     }
 
@@ -788,11 +788,11 @@ static int main_atoux(const char *arg, xoff_t *xo, xoff_t low, xoff_t high,
   }
 
   if (x < low) {
-    XPR(NT "-%c: minimum value: %" Q "u\n", which, low);
+    XPR(NT "-%c: minimum value: %" XD3_Q "u\n", which, low);
     return EXIT_FAILURE;
   }
   if (high != 0 && x > high) {
-    XPR(NT "-%c: maximum value: %" Q "u\n", which, high);
+    XPR(NT "-%c: maximum value: %" XD3_Q "u\n", which, high);
     return EXIT_FAILURE;
   }
   (*xo) = x;
@@ -1169,7 +1169,8 @@ static int xd3_win32_io(HANDLE file, uint8_t *buf, size_t size, int is_read,
 int main_file_read(main_file *ifile, uint8_t *buf, size_t size, size_t *nread,
                    const char *msg) {
   int ret = 0;
-  IF_DEBUG1(DP(RINT "[main] read %s up to %" Z "u\n", ifile->filename, size));
+  IF_DEBUG1(
+      DP(RINT "[main] read %s up to %" XD3_Z "u\n", ifile->filename, size));
 
 #if XD3_STDIO
   size_t result;
@@ -1192,7 +1193,7 @@ int main_file_read(main_file *ifile, uint8_t *buf, size_t size, size_t *nread,
     XPR(NT "%s: %s: %s\n", msg, ifile->filename, xd3_mainerror(ret));
   } else {
     if (option_verbose > 4) {
-      XPR(NT "read %s: %" Z "u bytes\n", ifile->filename, (*nread));
+      XPR(NT "read %s: %" XD3_Z "u bytes\n", ifile->filename, (*nread));
     }
     ifile->nread += (*nread);
   }
@@ -1204,7 +1205,7 @@ int main_file_write(main_file *ofile, uint8_t *buf, usize_t size,
                     const char *msg) {
   int ret = 0;
 
-  IF_DEBUG1(DP(RINT "[main] write %" W "u\n bytes", size));
+  IF_DEBUG1(DP(RINT "[main] write %" XD3_W "u\n bytes", size));
 
 #if XD3_STDIO
   usize_t result;
@@ -1227,7 +1228,7 @@ int main_file_write(main_file *ofile, uint8_t *buf, usize_t size,
     XPR(NT "%s: %s: %s\n", msg, ofile->filename, xd3_mainerror(ret));
   } else {
     if (option_verbose > 5) {
-      XPR(NT "write %s: %" W "u bytes\n", ofile->filename, size);
+      XPR(NT "write %s: %" XD3_W "u bytes\n", ofile->filename, size);
     }
     ofile->nwrite += size;
   }
@@ -1274,7 +1275,7 @@ static int main_file_seek(main_file *xfile, xoff_t pos) {
 static int main_write_output(xd3_stream *stream, main_file *ofile) {
   int ret;
 
-  IF_DEBUG1(DP(RINT "[main] write(%s) %" W "u\n bytes", ofile->filename,
+  IF_DEBUG1(DP(RINT "[main] write(%s) %" XD3_W "u\n bytes", ofile->filename,
                stream->avail_out));
 
 #if XD3_ARMOR
@@ -1427,7 +1428,7 @@ static int main_print_window(xd3_stream *stream, main_file *xfile) {
     usize_t size_before = size;
 
     if ((ret = xd3_decode_instruction(stream))) {
-      XPR(NT "instruction decode error at %" Q "u: %s\n",
+      XPR(NT "instruction decode error at %" XD3_Q "u: %s\n",
           stream->dec_winstart + size, stream->msg);
       return ret;
     }
@@ -1435,8 +1436,8 @@ static int main_print_window(xd3_stream *stream, main_file *xfile) {
     addr_bytes = (usize_t)(stream->addr_sect.buf - addr_before);
     inst_bytes = (usize_t)(stream->inst_sect.buf - inst_before);
 
-    VC(UT "  %06" Q "u %03" W "u  %s %6" W "u", stream->dec_winstart + size,
-       option_print_cpymode ? code : 0,
+    VC(UT "  %06" XD3_Q "u %03" XD3_W "u  %s %6" XD3_W "u",
+       stream->dec_winstart + size, option_print_cpymode ? code : 0,
        xd3_rtype_to_string((xd3_rtype)stream->dec_current1.type,
                            option_print_cpymode),
        stream->dec_current1.size)
@@ -1445,10 +1446,12 @@ static int main_print_window(xd3_stream *stream, main_file *xfile) {
     if (stream->dec_current1.type != XD3_NOOP) {
       if (stream->dec_current1.type >= XD3_CPY) {
         if (stream->dec_current1.addr >= stream->dec_cpylen) {
-          VC(UT " T@%-6" W "u", stream->dec_current1.addr - stream->dec_cpylen)
+          VC(UT " T@%-6" XD3_W "u",
+             stream->dec_current1.addr - stream->dec_cpylen)
           VE;
         } else {
-          VC(UT " S@%-6" Q "u", stream->dec_cpyoff + stream->dec_current1.addr)
+          VC(UT " S@%-6" XD3_Q "u",
+             stream->dec_cpyoff + stream->dec_current1.addr)
           VE;
         }
       } else {
@@ -1459,7 +1462,7 @@ static int main_print_window(xd3_stream *stream, main_file *xfile) {
     }
 
     if (stream->dec_current2.type != XD3_NOOP) {
-      VC(UT "  %s %6" W "u",
+      VC(UT "  %s %6" XD3_W "u",
          xd3_rtype_to_string((xd3_rtype)stream->dec_current2.type,
                              option_print_cpymode),
          stream->dec_current2.size)
@@ -1467,10 +1470,12 @@ static int main_print_window(xd3_stream *stream, main_file *xfile) {
 
       if (stream->dec_current2.type >= XD3_CPY) {
         if (stream->dec_current2.addr >= stream->dec_cpylen) {
-          VC(UT " T@%-6" W "u", stream->dec_current2.addr - stream->dec_cpylen)
+          VC(UT " T@%-6" XD3_W "u",
+             stream->dec_current2.addr - stream->dec_cpylen)
           VE;
         } else {
-          VC(UT " S@%-6" Q "u", stream->dec_cpyoff + stream->dec_current2.addr)
+          VC(UT " S@%-6" XD3_Q "u",
+             stream->dec_cpyoff + stream->dec_current2.addr)
           VE;
         }
       }
@@ -1483,7 +1488,8 @@ static int main_print_window(xd3_stream *stream, main_file *xfile) {
     if (option_verbose && addr_bytes + inst_bytes >= (size - size_before) &&
         (stream->dec_current1.type >= XD3_CPY ||
          stream->dec_current2.type >= XD3_CPY)) {
-      VC(UT "  %06" Q "u (inefficiency) %" W "u encoded as %" W "u bytes\n",
+      VC(UT "  %06" XD3_Q "u (inefficiency) %" XD3_W "u encoded as %" XD3_W
+            "u bytes\n",
          stream->dec_winstart + size_before, size - size_before,
          addr_bytes + inst_bytes)
       VE;
@@ -1539,7 +1545,7 @@ static int main_print_func(xd3_stream *stream, main_file *xfile) {
 
   if (stream->dec_winstart == 0) {
     VC(UT "VCDIFF version:               0\n") VE;
-    VC(UT "VCDIFF header size:           %" W "u\n", stream->dec_hdrsize)
+    VC(UT "VCDIFF header size:           %" XD3_W "u\n", stream->dec_hdrsize)
     VE;
     VC(UT "VCDIFF header indicator:      ") VE;
     if ((stream->dec_hdr_ind & VCD_SECONDARY) != 0)
@@ -1592,7 +1598,8 @@ static int main_print_func(xd3_stream *stream, main_file *xfile) {
     VC(UT "\n") VE;
   }
 
-  VC(UT "VCDIFF window number:         %" Q "u\n", stream->current_window) VE;
+  VC(UT "VCDIFF window number:         %" XD3_Q "u\n", stream->current_window)
+  VE;
   VC(UT "VCDIFF window indicator:      ") VE;
   if ((stream->dec_win_ind & VCD_SOURCE) != 0)
     VC(UT "VCD_SOURCE ") VE;
@@ -1622,27 +1629,29 @@ static int main_print_func(xd3_stream *stream, main_file *xfile) {
   }
 
   if (stream->dec_winstart != 0) {
-    VC(UT "VCDIFF window at offset:      %" Q "u\n", stream->dec_winstart)
+    VC(UT "VCDIFF window at offset:      %" XD3_Q "u\n", stream->dec_winstart)
     VE;
   }
 
   if (SRCORTGT(stream->dec_win_ind)) {
-    VC(UT "VCDIFF copy window length:    %" W "u\n", stream->dec_cpylen) VE;
-    VC(UT "VCDIFF copy window offset:    %" Q "u\n", stream->dec_cpyoff) VE;
+    VC(UT "VCDIFF copy window length:    %" XD3_W "u\n", stream->dec_cpylen) VE;
+    VC(UT "VCDIFF copy window offset:    %" XD3_Q "u\n", stream->dec_cpyoff) VE;
   }
 
-  VC(UT "VCDIFF delta encoding length: %" W "u\n", (usize_t)stream->dec_enclen)
+  VC(UT "VCDIFF delta encoding length: %" XD3_W "u\n",
+     (usize_t)stream->dec_enclen)
   VE;
-  VC(UT "VCDIFF target window length:  %" W "u\n", (usize_t)stream->dec_tgtlen)
+  VC(UT "VCDIFF target window length:  %" XD3_W "u\n",
+     (usize_t)stream->dec_tgtlen)
   VE;
 
-  VC(UT "VCDIFF data section length:   %" W "u\n",
+  VC(UT "VCDIFF data section length:   %" XD3_W "u\n",
      (usize_t)stream->data_sect.size)
   VE;
-  VC(UT "VCDIFF inst section length:   %" W "u\n",
+  VC(UT "VCDIFF inst section length:   %" XD3_W "u\n",
      (usize_t)stream->inst_sect.size)
   VE;
-  VC(UT "VCDIFF addr section length:   %" W "u\n",
+  VC(UT "VCDIFF addr section length:   %" XD3_W "u\n",
      (usize_t)stream->addr_sect.size)
   VE;
 
@@ -2039,8 +2048,8 @@ static int main_merge_output(xd3_stream *stream, main_file *ofile) {
           addr = inst->addr - window_start;
         }
         IF_DEBUG2({
-          XPR(NTR "[merge copy] winpos %" W "u take %" W "u "
-                  "addr %" Q "u mode %u\n",
+          XPR(NTR "[merge copy] winpos %" XD3_W "u take %" XD3_W "u "
+                  "addr %" XD3_Q "u mode %u\n",
               window_pos, take, addr, inst->mode);
         });
         if ((ret = xd3_found_match(recode_stream, window_pos, take, addr,
@@ -2279,7 +2288,7 @@ static int main_pipe_copier(uint8_t *pipe_buf, usize_t pipe_bufsize,
   }
 
   if (option_verbose && skipped != 0) {
-    XPR(NT "skipping %" Q "u bytes in %s\n", skipped, ifile->filename);
+    XPR(NT "skipping %" XD3_Q "u bytes in %s\n", skipped, ifile->filename);
   }
   return 0;
 }
@@ -3654,7 +3663,7 @@ static int main_input(xd3_cmd cmd, main_file *ifile, main_file *ofile,
         if (!option_quiet && IS_ENCODE(cmd) && main_file_isopen(sfile)) {
           /* Warn when no source copies are found */
           if (option_verbose && !xd3_encoder_used_source(&stream)) {
-            XPR(NT "warning: input window %" Q "u..%" Q "u has "
+            XPR(NT "warning: input window %" XD3_Q "u..%" XD3_Q "u has "
                    "no source copies\n",
                 stream.current_window * winsize,
                 (stream.current_window + 1) * winsize);
@@ -3665,8 +3674,8 @@ static int main_input(xd3_cmd cmd, main_file *ifile, main_file *ofile,
            * when the sourcewin is decided early. */
           if (option_verbose > 1 && stream.srcwin_decided_early &&
               stream.i_slots_used > stream.iopt_size) {
-            XPR(NT "warning: input position %" Q "u overflowed "
-                   "instruction buffer, needed %" W "u (vs. %" W "u), "
+            XPR(NT "warning: input position %" XD3_Q "u overflowed "
+                   "instruction buffer, needed %" XD3_W "u (vs. %" XD3_W "u), "
                    "consider changing -I\n",
                 stream.current_window * winsize, stream.i_slots_used,
                 stream.iopt_size);
@@ -3685,7 +3694,7 @@ static int main_input(xd3_cmd cmd, main_file *ifile, main_file *ofile,
           last_total_out = stream.total_out;
 
           if (option_verbose > 1) {
-            XPR(NT "%" Q "u: in %s (%s): out %s (%s): "
+            XPR(NT "%" XD3_Q "u: in %s (%s): out %s (%s): "
                    "total in %s: out %s: %s: srcpos %s\n",
                 stream.current_window, main_format_bcnt(this_read, &rdb),
                 main_format_rate(this_read, millis, &rrateavg),
@@ -3696,7 +3705,7 @@ static int main_input(xd3_cmd cmd, main_file *ifile, main_file *ofile,
                 main_format_millis(millis, &tm),
                 main_format_bcnt(stream.srcwin_cksum_pos, &srcpos));
           } else {
-            XPR(NT "%" Q "u: in %s: out %s: total in %s: "
+            XPR(NT "%" XD3_Q "u: in %s: out %s: total in %s: "
                    "out %s: %s\n",
                 stream.current_window, main_format_bcnt(this_read, &rdb),
                 main_format_bcnt(this_write, &wdb),
@@ -3797,19 +3806,21 @@ done:
 #if XD3_ENCODER
   if (option_verbose > 1 && cmd == CMD_ENCODE) {
     XPR(NT "scanner configuration: %s\n", stream.smatcher.name);
-    XPR(NT "target hash table size: %" W "u\n", stream.small_hash.size);
+    XPR(NT "target hash table size: %" XD3_W "u\n", stream.small_hash.size);
     if (sfile != NULL && sfile->filename != NULL) {
-      XPR(NT "source hash table size: %" W "u\n", stream.large_hash.size);
+      XPR(NT "source hash table size: %" XD3_W "u\n", stream.large_hash.size);
     }
   }
 
   if (option_verbose > 2 && cmd == CMD_ENCODE) {
-    XPR(NT "source copies: %" Q "u (%" Q "u bytes)\n", stream.n_scpy,
+    XPR(NT "source copies: %" XD3_Q "u (%" XD3_Q "u bytes)\n", stream.n_scpy,
         stream.l_scpy);
-    XPR(NT "target copies: %" Q "u (%" Q "u bytes)\n", stream.n_tcpy,
+    XPR(NT "target copies: %" XD3_Q "u (%" XD3_Q "u bytes)\n", stream.n_tcpy,
         stream.l_tcpy);
-    XPR(NT "adds: %" Q "u (%" Q "u bytes)\n", stream.n_add, stream.l_add);
-    XPR(NT "runs: %" Q "u (%" Q "u bytes)\n", stream.n_run, stream.l_run);
+    XPR(NT "adds: %" XD3_Q "u (%" XD3_Q "u bytes)\n", stream.n_add,
+        stream.l_add);
+    XPR(NT "runs: %" XD3_Q "u (%" XD3_Q "u bytes)\n", stream.n_run,
+        stream.l_run);
   }
 #endif
 
@@ -3820,7 +3831,8 @@ done:
     long end_time = get_millisecs_now();
     xoff_t nwrite = ofile != NULL ? ofile->nwrite : 0;
 
-    XPR(NT "finished in %s; input %" Q "u output %" Q "u bytes (%0.2f%%)\n",
+    XPR(NT "finished in %s; input %" XD3_Q "u output %" XD3_Q
+           "u bytes (%0.2f%%)\n",
         main_format_millis(end_time - start_time, &tm), ifile->nread, nwrite,
         100.0 * nwrite / ifile->nread);
   }

--- a/xdelta3/xdelta3-second.h
+++ b/xdelta3/xdelta3-second.h
@@ -60,7 +60,7 @@ static inline int xd3_decode_bits(xd3_stream *stream, bit_state *bits,
 
 done:
 
-  IF_DEBUG2(DP(RINT "(d) %" W "u ", value));
+  IF_DEBUG2(DP(RINT "(d) %" XD3_W "u ", value));
 
   (*valuep) = value;
   return 0;
@@ -195,7 +195,7 @@ static inline int xd3_encode_bits(xd3_stream *stream, xd3_output **output,
     }
   } while (mask != 1);
 
-  IF_DEBUG2(DP(RINT "(e) %" W "u ", value));
+  IF_DEBUG2(DP(RINT "(e) %" XD3_W "u ", value));
 
   return 0;
 }
@@ -249,8 +249,8 @@ static int xd3_encode_secondary(xd3_stream *stream, xd3_output **head,
 
   if (comp_size < (orig_size - SECONDARY_MIN_SAVINGS) || cfg->inefficient) {
     if (comp_size < orig_size) {
-      IF_DEBUG1(DP(RINT "[encode_secondary] saved %" W "u bytes: %" W "u -> %" W
-                        "u (%0.2f%%)\n",
+      IF_DEBUG1(DP(RINT "[encode_secondary] saved %" XD3_W "u bytes: %" XD3_W
+                        "u -> %" XD3_W "u (%0.2f%%)\n",
                    orig_size - comp_size, orig_size, comp_size,
                    100.0 * (double)comp_size / (double)orig_size));
     }

--- a/xdelta3/xdelta3-test.h
+++ b/xdelta3/xdelta3-test.h
@@ -229,7 +229,7 @@ static int test_random_numbers(xd3_stream *stream, int ignore) {
 static int test_printf_xoff(xd3_stream *stream, int ignore) {
   char buf[64];
   xoff_t x = XOFF_T_MAX;
-  snprintf_func(buf, sizeof(buf), "%" Q "u", x);
+  snprintf_func(buf, sizeof(buf), "%" XD3_Q "u", x);
   const char *expect =
       XD3_USE_LARGEFILE64 ? "18446744073709551615" : "4294967295";
   if (strcmp(buf, expect) == 0) {
@@ -421,7 +421,7 @@ int test_compare_files(const char *tgt, const char *rec) {
 
     for (i = 0; i < oc; i += 1) {
       if (obuf[i] != rbuf[i]) {
-        XPR(NT "byte %u (read %u @ %" Q "u) %d != %d\n", (int)i, (int)oc,
+        XPR(NT "byte %u (read %u @ %" XD3_Q "u) %d != %d\n", (int)i, (int)oc,
             offset, obuf[i], rbuf[i]);
         diffs++;
         return XD3_INTERNAL;
@@ -1444,7 +1444,7 @@ static int test_secondary(xd3_stream *stream, const xd3_sec_type *sec,
 
       /* Encode data */
       if ((ret = sec->encode(stream, enc_stream, in_head, out_head, &cfg))) {
-        XPR(NT "test %" W "u: encode: %s", test_i, stream->msg);
+        XPR(NT "test %" XD3_W "u: encode: %s", test_i, stream->msg);
         goto fail;
       }
 
@@ -1479,7 +1479,7 @@ static int test_secondary(xd3_stream *stream, const xd3_sec_type *sec,
 
       if ((ret = test_secondary_decode(stream, sec, input_size, compress_size,
                                        dec_input, dec_correct, dec_output))) {
-        XPR(NT "test %" W "u: decode: %s", test_i, stream->msg);
+        XPR(NT "test %" XD3_W "u: decode: %s", test_i, stream->msg);
         goto fail;
       }
 
@@ -1825,7 +1825,7 @@ static int test_command_line_arguments(xd3_stream *stream, int ignore) {
     /* Check that it is not too small, not too large. */
     if (ratio >= TEST_ADD_RATIO + TEST_EPSILON) {
       XPR(NT "test encode with size ratio %.4f, "
-             "expected < %.4f (%" Q "u, %" Q "u)\n",
+             "expected < %.4f (%" XD3_Q "u, %" XD3_Q "u)\n",
           ratio, TEST_ADD_RATIO + TEST_EPSILON, dsize, tsize);
       stream->msg = "strange encoding";
       return XD3_INTERNAL;
@@ -3170,13 +3170,14 @@ static int test_string_matching(xd3_stream *stream, int ignore) {
         CHECK(0);
       }
 
-      snprintf_func(rptr, rbuf + TESTBUFSIZE - rptr, "%" W "u/%" W "u",
+      snprintf_func(rptr, rbuf + TESTBUFSIZE - rptr, "%" XD3_W "u/%" XD3_W "u",
                     inst->pos, inst->size);
       rptr += strlen(rptr);
 
       if (inst->type == XD3_CPY) {
         *rptr++ = '@';
-        snprintf_func(rptr, rbuf + TESTBUFSIZE - rptr, "%" Q "u", inst->addr);
+        snprintf_func(rptr, rbuf + TESTBUFSIZE - rptr, "%" XD3_Q "u",
+                      inst->addr);
         rptr += strlen(rptr);
       }
 
@@ -3191,7 +3192,7 @@ static int test_string_matching(xd3_stream *stream, int ignore) {
     }
 
     if (strcmp(rbuf, test->result) != 0) {
-      XPR(NT "test %" W "u: expected %s: got %s", i, test->result, rbuf);
+      XPR(NT "test %" XD3_W "u: expected %s: got %s", i, test->result, rbuf);
       stream->msg = "wrong result";
       return XD3_INTERNAL;
     }

--- a/xdelta3/xdelta3.c
+++ b/xdelta3/xdelta3.c
@@ -1410,7 +1410,7 @@ static void *xd3_alloc(xd3_stream *stream, usize_t elts, usize_t size) {
 
   if (a != NULL) {
     IF_DEBUG(stream->alloc_cnt += 1);
-    IF_DEBUG2(DP(RINT "[stream %p malloc] size %" W "u ptr %p\n",
+    IF_DEBUG2(DP(RINT "[stream %p malloc] size %" XD3_W "u ptr %p\n",
                  (void *)stream, elts * size, a));
   } else {
     stream->msg = "out of memory";
@@ -1792,20 +1792,20 @@ static int xd3_getblk(xd3_stream *stream, xoff_t blkno) {
     source->getblkno = blkno;
 
     if (stream->getblk == NULL) {
-      IF_DEBUG2(DP(RINT "[getblk] XD3_GETSRCBLK %" Q "u\n", blkno));
+      IF_DEBUG2(DP(RINT "[getblk] XD3_GETSRCBLK %" XD3_Q "u\n", blkno));
       stream->msg = "getblk source input";
       return XD3_GETSRCBLK;
     }
 
     ret = stream->getblk(stream, source, blkno);
     if (ret != 0) {
-      IF_DEBUG2(DP(RINT "[getblk] app error blkno %" Q "u: %s\n", blkno,
+      IF_DEBUG2(DP(RINT "[getblk] app error blkno %" XD3_Q "u: %s\n", blkno,
                    xd3_strerror(ret)));
       return ret;
     }
 
-    IF_DEBUG2(DP(RINT "[getblk] read source block %" Q "u onblk "
-                      "%" W "u blksize %" W "u max_blkno %" Q "u\n",
+    IF_DEBUG2(DP(RINT "[getblk] read source block %" XD3_Q "u onblk "
+                      "%" XD3_W "u blksize %" XD3_W "u max_blkno %" XD3_Q "u\n",
                  blkno, source->onblk, source->blksize, source->max_blkno));
   }
 
@@ -1813,12 +1813,12 @@ static int xd3_getblk(xd3_stream *stream, xoff_t blkno) {
     source->max_blkno = blkno;
 
     if (source->onblk == source->blksize) {
-      IF_DEBUG1(DP(RINT "[getblk] full source blkno %" Q "u: "
-                        "source length unknown %" Q "u\n",
+      IF_DEBUG1(DP(RINT "[getblk] full source blkno %" XD3_Q "u: "
+                        "source length unknown %" XD3_Q "u\n",
                    blkno, xd3_source_eof(source)));
     } else if (!source->eof_known) {
-      IF_DEBUG1(DP(RINT "[getblk] eof block has %" W "u bytes; "
-                        "source length known %" Q "u\n",
+      IF_DEBUG1(DP(RINT "[getblk] eof block has %" XD3_W "u bytes; "
+                        "source length known %" XD3_Q "u\n",
                    xd3_bytes_on_srcblk(source, blkno), xd3_source_eof(source)));
       source->eof_known = 1;
     }
@@ -1850,7 +1850,7 @@ int xd3_set_source(xd3_stream *stream, xd3_source *src) {
   if (xd3_check_pow2(src->blksize, &shiftby) != 0) {
     src->blksize = xd3_pow2_roundup(src->blksize);
     xd3_check_pow2(src->blksize, &shiftby);
-    IF_DEBUG1(DP(RINT "raising src_blksz to %" W "u\n", src->blksize));
+    IF_DEBUG1(DP(RINT "raising src_blksz to %" XD3_W "u\n", src->blksize));
   }
 
   src->shiftby = shiftby;
@@ -1858,7 +1858,7 @@ int xd3_set_source(xd3_stream *stream, xd3_source *src) {
 
   if (xd3_check_pow2(src->max_winsize, NULL) != 0) {
     src->max_winsize = xd3_xoff_roundup(src->max_winsize);
-    IF_DEBUG1(DP(RINT "raising src_maxsize to %" W "u\n", src->blksize));
+    IF_DEBUG1(DP(RINT "raising src_maxsize to %" XD3_W "u\n", src->blksize));
   }
   src->max_winsize = xd3_max(src->max_winsize, XD3_ALLOCSIZE);
 
@@ -1878,11 +1878,12 @@ int xd3_set_source_and_size(xd3_stream *stream, xd3_source *user_source,
   int ret = xd3_set_source(stream, user_source);
   if (ret == 0) {
     stream->src->eof_known = 1;
-    IF_DEBUG2(DP(RINT "[set source] size known %" Q "u\n", source_size));
+    IF_DEBUG2(DP(RINT "[set source] size known %" XD3_Q "u\n", source_size));
     xd3_blksize_div(source_size, stream->src, &stream->src->max_blkno,
                     &stream->src->onlastblk);
 
-    IF_DEBUG1(DP(RINT "[set source] size known %" Q "u max_blkno %" Q "u\n",
+    IF_DEBUG1(DP(RINT "[set source] size known %" XD3_Q "u max_blkno %" XD3_Q
+                      "u\n",
                  source_size, stream->src->max_blkno));
   }
   return ret;
@@ -2056,8 +2057,8 @@ static int xd3_iopt_finish_encoding(xd3_stream *stream, xd3_rinst *inst) {
 
     IF_DEBUG2({
       static int cnt;
-      DP(RINT "[iopt copy:%d] pos %" Q "u-%" Q "u addr %" Q "u-%" Q "u size %" W
-              "u\n",
+      DP(RINT "[iopt copy:%d] pos %" XD3_Q "u-%" XD3_Q "u addr %" XD3_Q
+              "u-%" XD3_Q "u size %" XD3_W "u\n",
          cnt++, stream->total_in + inst->pos,
          stream->total_in + inst->pos + inst->size, inst->addr,
          inst->addr + inst->size, inst->size);
@@ -2074,7 +2075,7 @@ static int xd3_iopt_finish_encoding(xd3_stream *stream, xd3_rinst *inst) {
 
     IF_DEBUG2({
       static int cnt;
-      DP(RINT "[iopt run:%d] pos %" Q "u size %" W "u\n", cnt++,
+      DP(RINT "[iopt run:%d] pos %" XD3_Q "u size %" XD3_W "u\n", cnt++,
          stream->total_in + inst->pos, inst->size);
     });
     break;
@@ -2090,7 +2091,7 @@ static int xd3_iopt_finish_encoding(xd3_stream *stream, xd3_rinst *inst) {
 
     IF_DEBUG2({
       static int cnt;
-      DP(RINT "[iopt add:%d] pos %" Q "u size %" W "u\n", cnt++,
+      DP(RINT "[iopt add:%d] pos %" XD3_Q "u size %" XD3_W "u\n", cnt++,
          stream->total_in + inst->pos, inst->size);
     });
 
@@ -2440,9 +2441,9 @@ static int xd3_emit_single(xd3_stream *stream, xd3_rinst *single,
   int has_size = stream->code_table[code].size1 == 0;
   int ret;
 
-  IF_DEBUG2(DP(RINT "[emit1] %" W "u %s (%" W "u) code %u\n", single->pos,
-               xd3_rtype_to_string((xd3_rtype)single->type, 0), single->size,
-               code));
+  IF_DEBUG2(DP(RINT "[emit1] %" XD3_W "u %s (%" XD3_W "u) code %u\n",
+               single->pos, xd3_rtype_to_string((xd3_rtype)single->type, 0),
+               single->size, code));
 
   if ((ret = xd3_emit_byte(stream, &INST_TAIL(stream), code))) {
     return ret;
@@ -2470,10 +2471,10 @@ static int xd3_emit_double(xd3_stream *stream, xd3_rinst *first,
     return ret;
   }
 
-  IF_DEBUG2(DP(RINT "[emit2]: %" W "u %s (%" W "u) %s (%" W "u) code %u\n",
-               first->pos, xd3_rtype_to_string((xd3_rtype)first->type, 0),
-               first->size, xd3_rtype_to_string((xd3_rtype)second->type, 0),
-               second->size, code));
+  IF_DEBUG2(DP(
+      RINT "[emit2]: %" XD3_W "u %s (%" XD3_W "u) %s (%" XD3_W "u) code %u\n",
+      first->pos, xd3_rtype_to_string((xd3_rtype)first->type, 0), first->size,
+      xd3_rtype_to_string((xd3_rtype)second->type, 0), second->size, code));
 
   return 0;
 }
@@ -2683,7 +2684,7 @@ static int xd3_encode_buffer_leftover(xd3_stream *stream) {
     XD3_ASSERT(stream->buf_avail == 0);
     XD3_ASSERT(stream->buf_leftavail < stream->winsize);
 
-    IF_DEBUG2(DP(RINT "[leftover] previous %" W "u avail %" W "u\n",
+    IF_DEBUG2(DP(RINT "[leftover] previous %" XD3_W "u avail %" XD3_W "u\n",
                  stream->buf_leftavail, stream->avail_in));
 
     memcpy(stream->buf_in, stream->buf_leftover, stream->buf_leftavail);
@@ -2707,12 +2708,12 @@ static int xd3_encode_buffer_leftover(xd3_stream *stream) {
   } else if ((stream->buf_avail < stream->winsize) &&
              !(stream->flags & XD3_FLUSH)) {
     /* Buffer has space */
-    IF_DEBUG2(DP(RINT "[leftover] emptied %" W "u\n", take));
+    IF_DEBUG2(DP(RINT "[leftover] emptied %" XD3_W "u\n", take));
     return XD3_INPUT;
   }
 
   /* Use the buffer: */
-  IF_DEBUG2(DP(RINT "[leftover] take %" W "u remaining %" W "u\n", take,
+  IF_DEBUG2(DP(RINT "[leftover] take %" XD3_W "u remaining %" XD3_W "u\n", take,
                stream->buf_leftavail));
   stream->next_in = stream->buf_in;
   stream->avail_in = stream->buf_avail;
@@ -2913,12 +2914,13 @@ int xd3_encode_input(xd3_stream *stream) {
 
     stream->enc_state = ENC_SEARCH;
 
-    IF_DEBUG2(DP(RINT "[WINSTART:%" Q "u] input bytes %" W "u offset %" Q "u\n",
+    IF_DEBUG2(DP(RINT "[WINSTART:%" XD3_Q "u] input bytes %" XD3_W
+                      "u offset %" XD3_Q "u\n",
                  stream->current_window, stream->avail_in, stream->total_in));
     return XD3_WINSTART;
 
   case ENC_SEARCH:
-    IF_DEBUG2(DP(RINT "[SEARCH] match_state %d avail_in %" W "u %s\n",
+    IF_DEBUG2(DP(RINT "[SEARCH] match_state %d avail_in %" XD3_W "u %s\n",
                  stream->match_state, stream->avail_in,
                  stream->src ? "source" : "no source"));
 
@@ -3040,7 +3042,7 @@ int xd3_encode_input(xd3_stream *stream) {
     stream->total_in += stream->avail_in;
     stream->enc_state = ENC_POSTWIN;
 
-    IF_DEBUG2(DP(RINT "[WINFINISH:%" Q "u] in=%" Q "u\n",
+    IF_DEBUG2(DP(RINT "[WINFINISH:%" XD3_Q "u] in=%" XD3_Q "u\n",
                  stream->current_window, stream->total_in));
     return XD3_WINFINISH;
 
@@ -3370,7 +3372,8 @@ static int xd3_srcwin_setup(xd3_stream *stream) {
      * for the second block. */
     src->srclen = xd3_min(src->srclen, xd3_source_eof(src) - src->srcbase);
   }
-  IF_DEBUG1(DP(RINT "[srcwin_setup_constrained] base %" Q "u len %" W "u\n",
+  IF_DEBUG1(DP(RINT "[srcwin_setup_constrained] base %" XD3_Q "u len %" XD3_W
+                    "u\n",
                src->srcbase, src->srclen));
 
   XD3_ASSERT(src->srclen);
@@ -3415,7 +3418,8 @@ static int xd3_source_match_setup(xd3_stream *stream, xoff_t srcpos) {
   if (srcpos < stream->srcwin_cksum_pos &&
       stream->srcwin_cksum_pos - srcpos > src->max_winsize) {
     IF_DEBUG2(DP(RINT "[match_setup] rejected due to src->max_winsize "
-                      "distance eof=%" Q "u srcpos=%" Q "u max_winsz=%" Q "u\n",
+                      "distance eof=%" XD3_Q "u srcpos=%" XD3_Q
+                      "u max_winsz=%" XD3_Q "u\n",
                  xd3_source_eof(src), srcpos, src->max_winsize));
     goto bad;
   }
@@ -3424,8 +3428,8 @@ static int xd3_source_match_setup(xd3_stream *stream, xoff_t srcpos) {
    * will experience XD3_TOOFARBACK at the first xd3_getblk call
    * because the input may have advanced up to one block beyond the
    * actual EOF. */
-  IF_DEBUG2(DP(RINT "[match_setup] %" Q "u srcpos %" Q "u, "
-                    "src->max_winsize %" Q "u\n",
+  IF_DEBUG2(DP(RINT "[match_setup] %" XD3_Q "u srcpos %" XD3_Q "u, "
+                    "src->max_winsize %" XD3_Q "u\n",
                stream->total_in + stream->input_position, srcpos,
                src->max_winsize));
 
@@ -3474,8 +3478,8 @@ static int xd3_source_match_setup(xd3_stream *stream, xoff_t srcpos) {
       }
     }
 
-    IF_DEBUG2(DP(RINT "[match_setup] srcpos %" Q "u (tgtpos %" Q "u) "
-                      "unrestricted maxback %" W "u maxfwd %" W "u\n",
+    IF_DEBUG2(DP(RINT "[match_setup] srcpos %" XD3_Q "u (tgtpos %" XD3_Q "u) "
+                      "unrestricted maxback %" XD3_W "u maxfwd %" XD3_W "u\n",
                  srcpos, stream->total_in + stream->input_position,
                  stream->match_maxback, stream->match_maxfwd));
     goto good;
@@ -3501,8 +3505,8 @@ static int xd3_source_match_setup(xd3_stream *stream, xoff_t srcpos) {
       stream->match_maxfwd = srcavail;
     }
 
-    IF_DEBUG2(DP(RINT "[match_setup] srcpos %" Q "u (tgtpos %" Q "u) "
-                      "restricted maxback %" W "u maxfwd %" W "u\n",
+    IF_DEBUG2(DP(RINT "[match_setup] srcpos %" XD3_Q "u (tgtpos %" XD3_Q "u) "
+                      "restricted maxback %" XD3_W "u maxfwd %" XD3_W "u\n",
                  srcpos, stream->total_in + stream->input_position,
                  stream->match_maxback, stream->match_maxfwd));
     goto good;
@@ -3569,7 +3573,8 @@ static int xd3_source_extend_match(xd3_stream *stream) {
   usize_t tryrem; /* tryrem is the number of matchable bytes */
   usize_t matched;
 
-  IF_DEBUG2(DP(RINT "[extend match] srcpos %" Q "u\n", stream->match_srcpos));
+  IF_DEBUG2(
+      DP(RINT "[extend match] srcpos %" XD3_Q "u\n", stream->match_srcpos));
 
   XD3_ASSERT(src != NULL);
 
@@ -3591,8 +3596,8 @@ static int xd3_source_extend_match(xd3_stream *stream) {
 
       if ((ret = xd3_getblk(stream, tryblk))) {
         if (ret == XD3_TOOFARBACK) {
-          IF_DEBUG2(DP(RINT "[maxback] %" Q "u TOOFARBACK: %" W "u INP %" Q
-                            "u CKSUM %" Q "u\n",
+          IF_DEBUG2(DP(RINT "[maxback] %" XD3_Q "u TOOFARBACK: %" XD3_W
+                            "u INP %" XD3_Q "u CKSUM %" XD3_Q "u\n",
                        tryblk, stream->match_back,
                        stream->total_in + stream->input_position,
                        stream->srcwin_cksum_pos));
@@ -3613,8 +3618,8 @@ static int xd3_source_extend_match(xd3_stream *stream) {
 
       tryrem = xd3_min(tryoff, stream->match_maxback - stream->match_back);
 
-      IF_DEBUG2(DP(RINT "[maxback] maxback %" W "u trysrc %" Q "u/%" W
-                        "u tgt %" W "u tryrem %" W "u\n",
+      IF_DEBUG2(DP(RINT "[maxback] maxback %" XD3_W "u trysrc %" XD3_Q
+                        "u/%" XD3_W "u tgt %" XD3_W "u tryrem %" XD3_W "u\n",
                    stream->match_maxback, tryblk, tryoff, streamoff, tryrem));
 
       /* TODO: This code can be optimized similar to xd3_match_forward() */
@@ -3647,8 +3652,8 @@ static int xd3_source_extend_match(xd3_stream *stream) {
 
     if ((ret = xd3_getblk(stream, tryblk))) {
       if (ret == XD3_TOOFARBACK) {
-        IF_DEBUG2(DP(RINT "[maxfwd] %" Q "u TOOFARBACK: %" W "u INP %" Q
-                          "u CKSUM %" Q "u\n",
+        IF_DEBUG2(DP(RINT "[maxfwd] %" XD3_Q "u TOOFARBACK: %" XD3_W
+                          "u INP %" XD3_Q "u CKSUM %" XD3_Q "u\n",
                      tryblk, stream->match_fwd,
                      stream->total_in + stream->input_position,
                      stream->srcwin_cksum_pos));
@@ -3684,7 +3689,8 @@ static int xd3_source_extend_match(xd3_stream *stream) {
 donefwd:
   stream->match_state = MATCH_SEARCHING;
 
-  IF_DEBUG2(DP(RINT "[extend match] input %" Q "u srcpos %" Q "u len %" W "u\n",
+  IF_DEBUG2(DP(RINT "[extend match] input %" XD3_Q "u srcpos %" XD3_Q
+                    "u len %" XD3_W "u\n",
                stream->input_position + stream->total_in, stream->match_srcpos,
                stream->match_fwd));
 
@@ -3731,8 +3737,8 @@ donefwd:
 
     IF_DEBUG2({
       static int x = 0;
-      DP(RINT "[source match:%d] length %" W "u <inp %" Q "u %" Q "u>  <src %" Q
-              "u %" Q "u> (%s)\n",
+      DP(RINT "[source match:%d] length %" XD3_W "u <inp %" XD3_Q "u %" XD3_Q
+              "u>  <src %" XD3_Q "u %" XD3_Q "u> (%s)\n",
          x++, match_length, stream->total_in + target_position,
          stream->total_in + target_position + match_length, match_position,
          match_position + match_length,
@@ -3820,8 +3826,9 @@ static usize_t xd3_smatch(xd3_stream *stream, usize_t base, usize_t scksum,
 
 again:
 
-  IF_DEBUG2(DP(RINT "smatch at base=%" W "u inp=%" W "u cksum=%" W "u\n", base,
-               stream->input_position, scksum));
+  IF_DEBUG2(DP(RINT "smatch at base=%" XD3_W "u inp=%" XD3_W "u cksum=%" XD3_W
+                    "u\n",
+               base, stream->input_position, scksum));
 
   /* For small matches, we can always go to the end-of-input because
    * the matching position must be less than the input position. */
@@ -4010,14 +4017,14 @@ static int xd3_srcwin_move_point(xd3_stream *stream, usize_t *next_move_point) {
         ret = XD3_INTERNAL;
       }
 
-      IF_DEBUG1(DP(RINT "[srcwin_move_point] async getblk return for %" Q
+      IF_DEBUG1(DP(RINT "[srcwin_move_point] async getblk return for %" XD3_Q
                         "u: %s\n",
                    blkno, xd3_strerror(ret)));
       return ret;
     }
 
-    IF_DEBUG1(DP(RINT "[srcwin_move_point] block %" Q "u T=%" Q "u S=%" Q
-                      "u L=%" Q "u EOF=%" Q "u %s\n",
+    IF_DEBUG1(DP(RINT "[srcwin_move_point] block %" XD3_Q "u T=%" XD3_Q
+                      "u S=%" XD3_Q "u L=%" XD3_Q "u EOF=%" XD3_Q "u %s\n",
                  blkno, stream->total_in + stream->input_position,
                  stream->srcwin_cksum_pos, target_cksum_pos,
                  xd3_source_eof(stream->src),
@@ -4027,7 +4034,7 @@ static int xd3_srcwin_move_point(xd3_stream *stream, usize_t *next_move_point) {
 
     if (blkpos < (ssize_t)stream->smatcher.large_look) {
       stream->srcwin_cksum_pos = (blkno + 1) * stream->src->blksize;
-      IF_DEBUG2(DP(RINT "[srcwin_move_point] continue (end-of-block): %" Z
+      IF_DEBUG2(DP(RINT "[srcwin_move_point] continue (end-of-block): %" XD3_Z
                         "d\n",
                    blkpos));
       continue;
@@ -4065,8 +4072,8 @@ static int xd3_srcwin_move_point(xd3_stream *stream, usize_t *next_move_point) {
     stream->srcwin_cksum_pos = (blkno + 1) * stream->src->blksize;
   }
 
-  IF_DEBUG1(DP(RINT "[srcwin_move_point] exited loop T=%" Q "u "
-                    "S=%" Q "u EOF=%" Q "u %s\n",
+  IF_DEBUG1(DP(RINT "[srcwin_move_point] exited loop T=%" XD3_Q "u "
+                    "S=%" XD3_Q "u EOF=%" XD3_Q "u %s\n",
                stream->total_in + stream->input_position,
                stream->srcwin_cksum_pos, xd3_source_eof(stream->src),
                stream->src->eof_known ? "known" : "unknown"));
@@ -4089,8 +4096,9 @@ static int xd3_srcwin_move_point(xd3_stream *stream, usize_t *next_move_point) {
       stream->input_position + stream->src->blksize -
       ((stream->srcwin_cksum_pos - target_cksum_pos) & stream->src->maskby);
 
-  IF_DEBUG2(DP(RINT "[srcwin_move_point] finished T=%" Q "u "
-                    "S=%" Q "u L=%" Q "u EOF=%" Q "u %s again in %" W "u\n",
+  IF_DEBUG2(DP(RINT "[srcwin_move_point] finished T=%" XD3_Q "u "
+                    "S=%" XD3_Q "u L=%" XD3_Q "u EOF=%" XD3_Q
+                    "u %s again in %" XD3_W "u\n",
                stream->total_in + stream->input_position,
                stream->srcwin_cksum_pos, target_cksum_pos,
                xd3_source_eof(stream->src),
@@ -4164,7 +4172,7 @@ static int XD3_TEMPLATE(xd3_string_match_)(xd3_stream *stream) {
   usize_t match_offset = 0;
   usize_t next_move_point = 0;
 
-  IF_DEBUG2(DP(RINT "[string_match] initial entry %" W "u\n",
+  IF_DEBUG2(DP(RINT "[string_match] initial entry %" XD3_W "u\n",
                stream->input_position));
 
   /* If there will be no compression due to settings or short input,
@@ -4182,8 +4190,8 @@ static int XD3_TEMPLATE(xd3_string_match_)(xd3_stream *stream) {
    * needs to be reset. */
 restartloop:
 
-  IF_DEBUG2(
-      DP(RINT "[string_match] restartloop %" W "u\n", stream->input_position));
+  IF_DEBUG2(DP(RINT "[string_match] restartloop %" XD3_W "u\n",
+               stream->input_position));
 
   /* If there is not enough input remaining for any kind of match,
      skip it. */
@@ -4339,9 +4347,9 @@ restartloop:
       if (match_length >= stream->min_match) {
         IF_DEBUG2({
           static int x = 0;
-          DP(RINT "[target match:%d] <inp %" W "u %" W "u>  <cpy %" W "u %" W
-                  "u> "
-                  "(-%" W "d) [ %" W "u bytes ]\n",
+          DP(RINT "[target match:%d] <inp %" XD3_W "u %" XD3_W
+                  "u>  <cpy %" XD3_W "u %" XD3_W "u> "
+                  "(-%" XD3_W "d) [ %" XD3_W "u bytes ]\n",
              x++, stream->input_position, stream->input_position + match_length,
              match_offset, match_offset + match_length,
              stream->input_position - match_offset, match_length);

--- a/xdelta3/xdelta3.h
+++ b/xdelta3/xdelta3.h
@@ -187,20 +187,20 @@ XD3_STATIC_ASSERT(SIZEOF_SIZE_T == sizeof(size_t),
 XD3_STATIC_ASSERT(SIZEOF_UNSIGNED_LONG_LONG == sizeof(unsigned long long),
                   "SIZEOF_UNSIGNED_LONG_LONG not correctly set");
 
-/* Set a xoff_t typedef and the "Q" printf insert. */
+/* Set a xoff_t typedef and the "XD3_Q" printf insert. */
 #if defined(_WIN32)
 typedef uint64_t xoff_t;
-#define Q "I64"
+#define XD3_Q "I64"
 #elif SIZEOF_UNSIGNED_LONG == 8
 typedef unsigned long xoff_t;
-#define Q "l"
+#define XD3_Q "l"
 #elif SIZEOF_SIZE_T == 8
 typedef size_t xoff_t;
-#define Q "z"
+#define XD3_Q "z"
 #elif SIZEOF_UNSIGNED_LONG_LONG == 8
 typedef unsigned long long xoff_t;
-#define Q "ll"
-#endif /* typedef and #define Q */
+#define XD3_Q "ll"
+#endif /* typedef and #define XD3_Q */
 
 #define SIZEOF_XOFF_T 8
 
@@ -215,26 +215,26 @@ typedef uint32_t xoff_t;
 #endif /* xoff_t is 32 bits */
 
 #define SIZEOF_XOFF_T 4
-#define Q
+#define XD3_Q
 #endif /* 64 vs 32 bit xoff_t */
 
 /* Settings based on the size of usize_t (32 and 64 bit window size) */
 #if XD3_USE_LARGESIZET
 
-/* Set a usize_ttypedef and the "W" printf insert. */
+/* Set a usize_ttypedef and the "XD3_W" printf insert. */
 #if defined(_WIN32)
 typedef uint64_t usize_t;
-#define W "I64"
+#define XD3_W "I64"
 #elif SIZEOF_UNSIGNED_LONG == 8
 typedef unsigned long usize_t;
-#define W "l"
+#define XD3_W "l"
 #elif SIZEOF_SIZE_T == 8
 typedef size_t usize_t;
-#define W "z"
+#define XD3_W "z"
 #elif SIZEOF_UNSIGNED_LONG_LONG == 8
 typedef unsigned long long usize_t;
-#define W "ll"
-#endif /* typedef and #define W */
+#define XD3_W "ll"
+#endif /* typedef and #define XD3_W */
 
 #define SIZEOF_USIZE_T 8
 
@@ -249,19 +249,19 @@ typedef uint32_t usize_t;
 #endif /* usize_t is 32 bits */
 
 #define SIZEOF_USIZE_T 4
-#define W
+#define XD3_W
 
 #endif /* 64 vs 32 bit usize_t */
 
 /* Settings based on the size of size_t (the system-provided,
  * usually-but-maybe-not an unsigned type) */
 #if SIZEOF_SIZE_T == 4
-#define Z "z"
+#define XD3_Z "z"
 #elif SIZEOF_SIZE_T == 8
 #ifdef _WIN32
-#define Z "I64"
+#define XD3_Z "I64"
 #else /* !_WIN32 */
-#define Z "z"
+#define XD3_Z "z"
 #endif /* Windows or not */
 #else
 #error Bad configure script


### PR DESCRIPTION
The public header xdelta3.h defined single-letter macros Q, W and Z for printf length modifiers. These pollute the global namespace and break compilation when xdelta3.h is included alongside code that uses Q, W or Z as identifiers (e.g. parameter names in sqlite3 headers).

Prefix them with XD3_ and update all internal uses.

Fixes #292